### PR TITLE
Latest

### DIFF
--- a/profiles/2017-03-09/compute/mgmt/compute/computeapi/models.go
+++ b/profiles/2017-03-09/compute/mgmt/compute/computeapi/models.go
@@ -1,6 +1,6 @@
 // +build go1.9
 
-// Copyright 2018 Microsoft Corporation
+// Copyright 2019 Microsoft Corporation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/profiles/2017-03-09/compute/mgmt/compute/models.go
+++ b/profiles/2017-03-09/compute/mgmt/compute/models.go
@@ -1,6 +1,6 @@
 // +build go1.9
 
-// Copyright 2018 Microsoft Corporation
+// Copyright 2019 Microsoft Corporation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/profiles/2017-03-09/keyvault/keyvault/keyvaultapi/models.go
+++ b/profiles/2017-03-09/keyvault/keyvault/keyvaultapi/models.go
@@ -1,6 +1,6 @@
 // +build go1.9
 
-// Copyright 2018 Microsoft Corporation
+// Copyright 2019 Microsoft Corporation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/profiles/2017-03-09/keyvault/keyvault/models.go
+++ b/profiles/2017-03-09/keyvault/keyvault/models.go
@@ -1,6 +1,6 @@
 // +build go1.9
 
-// Copyright 2018 Microsoft Corporation
+// Copyright 2019 Microsoft Corporation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/profiles/2017-03-09/keyvault/mgmt/keyvault/keyvaultapi/models.go
+++ b/profiles/2017-03-09/keyvault/mgmt/keyvault/keyvaultapi/models.go
@@ -1,6 +1,6 @@
 // +build go1.9
 
-// Copyright 2018 Microsoft Corporation
+// Copyright 2019 Microsoft Corporation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/profiles/2017-03-09/keyvault/mgmt/keyvault/models.go
+++ b/profiles/2017-03-09/keyvault/mgmt/keyvault/models.go
@@ -1,6 +1,6 @@
 // +build go1.9
 
-// Copyright 2018 Microsoft Corporation
+// Copyright 2019 Microsoft Corporation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/profiles/2017-03-09/network/mgmt/network/models.go
+++ b/profiles/2017-03-09/network/mgmt/network/models.go
@@ -1,6 +1,6 @@
 // +build go1.9
 
-// Copyright 2018 Microsoft Corporation
+// Copyright 2019 Microsoft Corporation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/profiles/2017-03-09/network/mgmt/network/networkapi/models.go
+++ b/profiles/2017-03-09/network/mgmt/network/networkapi/models.go
@@ -1,6 +1,6 @@
 // +build go1.9
 
-// Copyright 2018 Microsoft Corporation
+// Copyright 2019 Microsoft Corporation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/profiles/2017-03-09/resources/mgmt/features/featuresapi/models.go
+++ b/profiles/2017-03-09/resources/mgmt/features/featuresapi/models.go
@@ -1,6 +1,6 @@
 // +build go1.9
 
-// Copyright 2018 Microsoft Corporation
+// Copyright 2019 Microsoft Corporation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/profiles/2017-03-09/resources/mgmt/features/models.go
+++ b/profiles/2017-03-09/resources/mgmt/features/models.go
@@ -1,6 +1,6 @@
 // +build go1.9
 
-// Copyright 2018 Microsoft Corporation
+// Copyright 2019 Microsoft Corporation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/profiles/2017-03-09/resources/mgmt/links/linksapi/models.go
+++ b/profiles/2017-03-09/resources/mgmt/links/linksapi/models.go
@@ -1,6 +1,6 @@
 // +build go1.9
 
-// Copyright 2018 Microsoft Corporation
+// Copyright 2019 Microsoft Corporation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/profiles/2017-03-09/resources/mgmt/links/models.go
+++ b/profiles/2017-03-09/resources/mgmt/links/models.go
@@ -1,6 +1,6 @@
 // +build go1.9
 
-// Copyright 2018 Microsoft Corporation
+// Copyright 2019 Microsoft Corporation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/profiles/2017-03-09/resources/mgmt/locks/locksapi/models.go
+++ b/profiles/2017-03-09/resources/mgmt/locks/locksapi/models.go
@@ -1,6 +1,6 @@
 // +build go1.9
 
-// Copyright 2018 Microsoft Corporation
+// Copyright 2019 Microsoft Corporation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/profiles/2017-03-09/resources/mgmt/locks/models.go
+++ b/profiles/2017-03-09/resources/mgmt/locks/models.go
@@ -1,6 +1,6 @@
 // +build go1.9
 
-// Copyright 2018 Microsoft Corporation
+// Copyright 2019 Microsoft Corporation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/profiles/2017-03-09/resources/mgmt/policy/models.go
+++ b/profiles/2017-03-09/resources/mgmt/policy/models.go
@@ -1,6 +1,6 @@
 // +build go1.9
 
-// Copyright 2018 Microsoft Corporation
+// Copyright 2019 Microsoft Corporation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/profiles/2017-03-09/resources/mgmt/resources/models.go
+++ b/profiles/2017-03-09/resources/mgmt/resources/models.go
@@ -1,6 +1,6 @@
 // +build go1.9
 
-// Copyright 2018 Microsoft Corporation
+// Copyright 2019 Microsoft Corporation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/profiles/2017-03-09/resources/mgmt/resources/resourcesapi/models.go
+++ b/profiles/2017-03-09/resources/mgmt/resources/resourcesapi/models.go
@@ -1,6 +1,6 @@
 // +build go1.9
 
-// Copyright 2018 Microsoft Corporation
+// Copyright 2019 Microsoft Corporation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/profiles/2017-03-09/resources/mgmt/subscriptions/models.go
+++ b/profiles/2017-03-09/resources/mgmt/subscriptions/models.go
@@ -1,6 +1,6 @@
 // +build go1.9
 
-// Copyright 2018 Microsoft Corporation
+// Copyright 2019 Microsoft Corporation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/profiles/2017-03-09/resources/mgmt/subscriptions/subscriptionsapi/models.go
+++ b/profiles/2017-03-09/resources/mgmt/subscriptions/subscriptionsapi/models.go
@@ -1,6 +1,6 @@
 // +build go1.9
 
-// Copyright 2018 Microsoft Corporation
+// Copyright 2019 Microsoft Corporation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/profiles/2017-03-09/storage/mgmt/storage/models.go
+++ b/profiles/2017-03-09/storage/mgmt/storage/models.go
@@ -1,6 +1,6 @@
 // +build go1.9
 
-// Copyright 2018 Microsoft Corporation
+// Copyright 2019 Microsoft Corporation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/profiles/2017-03-09/storage/mgmt/storage/storageapi/models.go
+++ b/profiles/2017-03-09/storage/mgmt/storage/storageapi/models.go
@@ -1,6 +1,6 @@
 // +build go1.9
 
-// Copyright 2018 Microsoft Corporation
+// Copyright 2019 Microsoft Corporation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/profiles/2018-03-01/authorization/mgmt/authorization/authorizationapi/models.go
+++ b/profiles/2018-03-01/authorization/mgmt/authorization/authorizationapi/models.go
@@ -1,6 +1,6 @@
 // +build go1.9
 
-// Copyright 2018 Microsoft Corporation
+// Copyright 2019 Microsoft Corporation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/profiles/2018-03-01/authorization/mgmt/authorization/models.go
+++ b/profiles/2018-03-01/authorization/mgmt/authorization/models.go
@@ -1,6 +1,6 @@
 // +build go1.9
 
-// Copyright 2018 Microsoft Corporation
+// Copyright 2019 Microsoft Corporation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/profiles/2018-03-01/compute/mgmt/compute/computeapi/models.go
+++ b/profiles/2018-03-01/compute/mgmt/compute/computeapi/models.go
@@ -1,6 +1,6 @@
 // +build go1.9
 
-// Copyright 2018 Microsoft Corporation
+// Copyright 2019 Microsoft Corporation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/profiles/2018-03-01/compute/mgmt/compute/models.go
+++ b/profiles/2018-03-01/compute/mgmt/compute/models.go
@@ -1,6 +1,6 @@
 // +build go1.9
 
-// Copyright 2018 Microsoft Corporation
+// Copyright 2019 Microsoft Corporation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/profiles/2018-03-01/dns/mgmt/dns/dnsapi/models.go
+++ b/profiles/2018-03-01/dns/mgmt/dns/dnsapi/models.go
@@ -1,6 +1,6 @@
 // +build go1.9
 
-// Copyright 2018 Microsoft Corporation
+// Copyright 2019 Microsoft Corporation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/profiles/2018-03-01/dns/mgmt/dns/models.go
+++ b/profiles/2018-03-01/dns/mgmt/dns/models.go
@@ -1,6 +1,6 @@
 // +build go1.9
 
-// Copyright 2018 Microsoft Corporation
+// Copyright 2019 Microsoft Corporation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/profiles/2018-03-01/keyvault/keyvault/keyvaultapi/models.go
+++ b/profiles/2018-03-01/keyvault/keyvault/keyvaultapi/models.go
@@ -1,6 +1,6 @@
 // +build go1.9
 
-// Copyright 2018 Microsoft Corporation
+// Copyright 2019 Microsoft Corporation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/profiles/2018-03-01/keyvault/keyvault/models.go
+++ b/profiles/2018-03-01/keyvault/keyvault/models.go
@@ -1,6 +1,6 @@
 // +build go1.9
 
-// Copyright 2018 Microsoft Corporation
+// Copyright 2019 Microsoft Corporation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/profiles/2018-03-01/keyvault/mgmt/keyvault/keyvaultapi/models.go
+++ b/profiles/2018-03-01/keyvault/mgmt/keyvault/keyvaultapi/models.go
@@ -1,6 +1,6 @@
 // +build go1.9
 
-// Copyright 2018 Microsoft Corporation
+// Copyright 2019 Microsoft Corporation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/profiles/2018-03-01/keyvault/mgmt/keyvault/models.go
+++ b/profiles/2018-03-01/keyvault/mgmt/keyvault/models.go
@@ -1,6 +1,6 @@
 // +build go1.9
 
-// Copyright 2018 Microsoft Corporation
+// Copyright 2019 Microsoft Corporation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/profiles/2018-03-01/network/mgmt/network/models.go
+++ b/profiles/2018-03-01/network/mgmt/network/models.go
@@ -1,6 +1,6 @@
 // +build go1.9
 
-// Copyright 2018 Microsoft Corporation
+// Copyright 2019 Microsoft Corporation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/profiles/2018-03-01/network/mgmt/network/networkapi/models.go
+++ b/profiles/2018-03-01/network/mgmt/network/networkapi/models.go
@@ -1,6 +1,6 @@
 // +build go1.9
 
-// Copyright 2018 Microsoft Corporation
+// Copyright 2019 Microsoft Corporation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/profiles/2018-03-01/resources/mgmt/links/linksapi/models.go
+++ b/profiles/2018-03-01/resources/mgmt/links/linksapi/models.go
@@ -1,6 +1,6 @@
 // +build go1.9
 
-// Copyright 2018 Microsoft Corporation
+// Copyright 2019 Microsoft Corporation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/profiles/2018-03-01/resources/mgmt/links/models.go
+++ b/profiles/2018-03-01/resources/mgmt/links/models.go
@@ -1,6 +1,6 @@
 // +build go1.9
 
-// Copyright 2018 Microsoft Corporation
+// Copyright 2019 Microsoft Corporation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/profiles/2018-03-01/resources/mgmt/locks/locksapi/models.go
+++ b/profiles/2018-03-01/resources/mgmt/locks/locksapi/models.go
@@ -1,6 +1,6 @@
 // +build go1.9
 
-// Copyright 2018 Microsoft Corporation
+// Copyright 2019 Microsoft Corporation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/profiles/2018-03-01/resources/mgmt/locks/models.go
+++ b/profiles/2018-03-01/resources/mgmt/locks/models.go
@@ -1,6 +1,6 @@
 // +build go1.9
 
-// Copyright 2018 Microsoft Corporation
+// Copyright 2019 Microsoft Corporation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/profiles/2018-03-01/resources/mgmt/policy/models.go
+++ b/profiles/2018-03-01/resources/mgmt/policy/models.go
@@ -1,6 +1,6 @@
 // +build go1.9
 
-// Copyright 2018 Microsoft Corporation
+// Copyright 2019 Microsoft Corporation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/profiles/2018-03-01/resources/mgmt/policy/policyapi/models.go
+++ b/profiles/2018-03-01/resources/mgmt/policy/policyapi/models.go
@@ -1,6 +1,6 @@
 // +build go1.9
 
-// Copyright 2018 Microsoft Corporation
+// Copyright 2019 Microsoft Corporation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/profiles/2018-03-01/resources/mgmt/resources/models.go
+++ b/profiles/2018-03-01/resources/mgmt/resources/models.go
@@ -1,6 +1,6 @@
 // +build go1.9
 
-// Copyright 2018 Microsoft Corporation
+// Copyright 2019 Microsoft Corporation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/profiles/2018-03-01/resources/mgmt/resources/resourcesapi/models.go
+++ b/profiles/2018-03-01/resources/mgmt/resources/resourcesapi/models.go
@@ -1,6 +1,6 @@
 // +build go1.9
 
-// Copyright 2018 Microsoft Corporation
+// Copyright 2019 Microsoft Corporation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/profiles/2018-03-01/resources/mgmt/subscriptions/models.go
+++ b/profiles/2018-03-01/resources/mgmt/subscriptions/models.go
@@ -1,6 +1,6 @@
 // +build go1.9
 
-// Copyright 2018 Microsoft Corporation
+// Copyright 2019 Microsoft Corporation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/profiles/2018-03-01/resources/mgmt/subscriptions/subscriptionsapi/models.go
+++ b/profiles/2018-03-01/resources/mgmt/subscriptions/subscriptionsapi/models.go
@@ -1,6 +1,6 @@
 // +build go1.9
 
-// Copyright 2018 Microsoft Corporation
+// Copyright 2019 Microsoft Corporation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/profiles/2018-03-01/storage/mgmt/storage/models.go
+++ b/profiles/2018-03-01/storage/mgmt/storage/models.go
@@ -1,6 +1,6 @@
 // +build go1.9
 
-// Copyright 2018 Microsoft Corporation
+// Copyright 2019 Microsoft Corporation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/profiles/2018-03-01/storage/mgmt/storage/storageapi/models.go
+++ b/profiles/2018-03-01/storage/mgmt/storage/storageapi/models.go
@@ -1,6 +1,6 @@
 // +build go1.9
 
-// Copyright 2018 Microsoft Corporation
+// Copyright 2019 Microsoft Corporation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/profiles/2018-03-01/web/mgmt/web/models.go
+++ b/profiles/2018-03-01/web/mgmt/web/models.go
@@ -1,6 +1,6 @@
 // +build go1.9
 
-// Copyright 2018 Microsoft Corporation
+// Copyright 2019 Microsoft Corporation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/profiles/2018-03-01/web/mgmt/web/webapi/models.go
+++ b/profiles/2018-03-01/web/mgmt/web/webapi/models.go
@@ -1,6 +1,6 @@
 // +build go1.9
 
-// Copyright 2018 Microsoft Corporation
+// Copyright 2019 Microsoft Corporation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/profiles/latest/adhybridhealthservice/mgmt/adhybridhealthservice/adhybridhealthserviceapi/models.go
+++ b/profiles/latest/adhybridhealthservice/mgmt/adhybridhealthservice/adhybridhealthserviceapi/models.go
@@ -1,6 +1,6 @@
 // +build go1.9
 
-// Copyright 2018 Microsoft Corporation
+// Copyright 2019 Microsoft Corporation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/profiles/latest/adhybridhealthservice/mgmt/adhybridhealthservice/models.go
+++ b/profiles/latest/adhybridhealthservice/mgmt/adhybridhealthservice/models.go
@@ -1,6 +1,6 @@
 // +build go1.9
 
-// Copyright 2018 Microsoft Corporation
+// Copyright 2019 Microsoft Corporation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/profiles/latest/advisor/mgmt/advisor/advisorapi/models.go
+++ b/profiles/latest/advisor/mgmt/advisor/advisorapi/models.go
@@ -1,6 +1,6 @@
 // +build go1.9
 
-// Copyright 2018 Microsoft Corporation
+// Copyright 2019 Microsoft Corporation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/profiles/latest/advisor/mgmt/advisor/models.go
+++ b/profiles/latest/advisor/mgmt/advisor/models.go
@@ -1,6 +1,6 @@
 // +build go1.9
 
-// Copyright 2018 Microsoft Corporation
+// Copyright 2019 Microsoft Corporation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/profiles/latest/alertsmanagement/mgmt/alertsmanagement/alertsmanagementapi/models.go
+++ b/profiles/latest/alertsmanagement/mgmt/alertsmanagement/alertsmanagementapi/models.go
@@ -1,6 +1,6 @@
 // +build go1.9
 
-// Copyright 2018 Microsoft Corporation
+// Copyright 2019 Microsoft Corporation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/profiles/latest/alertsmanagement/mgmt/alertsmanagement/models.go
+++ b/profiles/latest/alertsmanagement/mgmt/alertsmanagement/models.go
@@ -1,6 +1,6 @@
 // +build go1.9
 
-// Copyright 2018 Microsoft Corporation
+// Copyright 2019 Microsoft Corporation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/profiles/latest/analysisservices/mgmt/analysisservices/analysisservicesapi/models.go
+++ b/profiles/latest/analysisservices/mgmt/analysisservices/analysisservicesapi/models.go
@@ -1,6 +1,6 @@
 // +build go1.9
 
-// Copyright 2018 Microsoft Corporation
+// Copyright 2019 Microsoft Corporation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/profiles/latest/analysisservices/mgmt/analysisservices/models.go
+++ b/profiles/latest/analysisservices/mgmt/analysisservices/models.go
@@ -1,6 +1,6 @@
 // +build go1.9
 
-// Copyright 2018 Microsoft Corporation
+// Copyright 2019 Microsoft Corporation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/profiles/latest/apimanagement/mgmt/apimanagement/apimanagementapi/models.go
+++ b/profiles/latest/apimanagement/mgmt/apimanagement/apimanagementapi/models.go
@@ -1,6 +1,6 @@
 // +build go1.9
 
-// Copyright 2018 Microsoft Corporation
+// Copyright 2019 Microsoft Corporation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/profiles/latest/apimanagement/mgmt/apimanagement/models.go
+++ b/profiles/latest/apimanagement/mgmt/apimanagement/models.go
@@ -1,6 +1,6 @@
 // +build go1.9
 
-// Copyright 2018 Microsoft Corporation
+// Copyright 2019 Microsoft Corporation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/profiles/latest/appinsights/insights/models.go
+++ b/profiles/latest/appinsights/insights/models.go
@@ -1,6 +1,6 @@
 // +build go1.9
 
-// Copyright 2018 Microsoft Corporation
+// Copyright 2019 Microsoft Corporation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/profiles/latest/appinsights/mgmt/insights/insightsapi/models.go
+++ b/profiles/latest/appinsights/mgmt/insights/insightsapi/models.go
@@ -1,6 +1,6 @@
 // +build go1.9
 
-// Copyright 2018 Microsoft Corporation
+// Copyright 2019 Microsoft Corporation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/profiles/latest/appinsights/mgmt/insights/models.go
+++ b/profiles/latest/appinsights/mgmt/insights/models.go
@@ -1,6 +1,6 @@
 // +build go1.9
 
-// Copyright 2018 Microsoft Corporation
+// Copyright 2019 Microsoft Corporation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/profiles/latest/authorization/mgmt/authorization/authorizationapi/models.go
+++ b/profiles/latest/authorization/mgmt/authorization/authorizationapi/models.go
@@ -1,6 +1,6 @@
 // +build go1.9
 
-// Copyright 2018 Microsoft Corporation
+// Copyright 2019 Microsoft Corporation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/profiles/latest/authorization/mgmt/authorization/models.go
+++ b/profiles/latest/authorization/mgmt/authorization/models.go
@@ -1,6 +1,6 @@
 // +build go1.9
 
-// Copyright 2018 Microsoft Corporation
+// Copyright 2019 Microsoft Corporation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/profiles/latest/automation/mgmt/automation/automationapi/models.go
+++ b/profiles/latest/automation/mgmt/automation/automationapi/models.go
@@ -1,6 +1,6 @@
 // +build go1.9
 
-// Copyright 2018 Microsoft Corporation
+// Copyright 2019 Microsoft Corporation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/profiles/latest/automation/mgmt/automation/models.go
+++ b/profiles/latest/automation/mgmt/automation/models.go
@@ -1,6 +1,6 @@
 // +build go1.9
 
-// Copyright 2018 Microsoft Corporation
+// Copyright 2019 Microsoft Corporation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/profiles/latest/azsadmin/mgmt/fabric/models.go
+++ b/profiles/latest/azsadmin/mgmt/fabric/models.go
@@ -1,6 +1,6 @@
 // +build go1.9
 
-// Copyright 2018 Microsoft Corporation
+// Copyright 2019 Microsoft Corporation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/profiles/latest/azsadmin/mgmt/infrastructureinsights/models.go
+++ b/profiles/latest/azsadmin/mgmt/infrastructureinsights/models.go
@@ -1,6 +1,6 @@
 // +build go1.9
 
-// Copyright 2018 Microsoft Corporation
+// Copyright 2019 Microsoft Corporation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/profiles/latest/azurestack/mgmt/azurestack/azurestackapi/models.go
+++ b/profiles/latest/azurestack/mgmt/azurestack/azurestackapi/models.go
@@ -1,6 +1,6 @@
 // +build go1.9
 
-// Copyright 2018 Microsoft Corporation
+// Copyright 2019 Microsoft Corporation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/profiles/latest/azurestack/mgmt/azurestack/models.go
+++ b/profiles/latest/azurestack/mgmt/azurestack/models.go
@@ -1,6 +1,6 @@
 // +build go1.9
 
-// Copyright 2018 Microsoft Corporation
+// Copyright 2019 Microsoft Corporation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/profiles/latest/batch/batch/batchapi/models.go
+++ b/profiles/latest/batch/batch/batchapi/models.go
@@ -1,6 +1,6 @@
 // +build go1.9
 
-// Copyright 2018 Microsoft Corporation
+// Copyright 2019 Microsoft Corporation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/profiles/latest/batch/batch/models.go
+++ b/profiles/latest/batch/batch/models.go
@@ -1,6 +1,6 @@
 // +build go1.9
 
-// Copyright 2018 Microsoft Corporation
+// Copyright 2019 Microsoft Corporation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/profiles/latest/batch/mgmt/batch/batchapi/models.go
+++ b/profiles/latest/batch/mgmt/batch/batchapi/models.go
@@ -1,6 +1,6 @@
 // +build go1.9
 
-// Copyright 2018 Microsoft Corporation
+// Copyright 2019 Microsoft Corporation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/profiles/latest/batch/mgmt/batch/models.go
+++ b/profiles/latest/batch/mgmt/batch/models.go
@@ -1,6 +1,6 @@
 // +build go1.9
 
-// Copyright 2018 Microsoft Corporation
+// Copyright 2019 Microsoft Corporation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/profiles/latest/batchai/mgmt/batchai/batchaiapi/models.go
+++ b/profiles/latest/batchai/mgmt/batchai/batchaiapi/models.go
@@ -1,6 +1,6 @@
 // +build go1.9
 
-// Copyright 2018 Microsoft Corporation
+// Copyright 2019 Microsoft Corporation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/profiles/latest/batchai/mgmt/batchai/models.go
+++ b/profiles/latest/batchai/mgmt/batchai/models.go
@@ -1,6 +1,6 @@
 // +build go1.9
 
-// Copyright 2018 Microsoft Corporation
+// Copyright 2019 Microsoft Corporation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/profiles/latest/cdn/mgmt/cdn/cdnapi/models.go
+++ b/profiles/latest/cdn/mgmt/cdn/cdnapi/models.go
@@ -1,6 +1,6 @@
 // +build go1.9
 
-// Copyright 2018 Microsoft Corporation
+// Copyright 2019 Microsoft Corporation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/profiles/latest/cdn/mgmt/cdn/models.go
+++ b/profiles/latest/cdn/mgmt/cdn/models.go
@@ -1,6 +1,6 @@
 // +build go1.9
 
-// Copyright 2018 Microsoft Corporation
+// Copyright 2019 Microsoft Corporation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/profiles/latest/cognitiveservices/autosuggest/autosuggestapi/models.go
+++ b/profiles/latest/cognitiveservices/autosuggest/autosuggestapi/models.go
@@ -1,6 +1,6 @@
 // +build go1.9
 
-// Copyright 2018 Microsoft Corporation
+// Copyright 2019 Microsoft Corporation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/profiles/latest/cognitiveservices/autosuggest/models.go
+++ b/profiles/latest/cognitiveservices/autosuggest/models.go
@@ -1,6 +1,6 @@
 // +build go1.9
 
-// Copyright 2018 Microsoft Corporation
+// Copyright 2019 Microsoft Corporation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/profiles/latest/cognitiveservices/computervision/computervisionapi/models.go
+++ b/profiles/latest/cognitiveservices/computervision/computervisionapi/models.go
@@ -1,6 +1,6 @@
 // +build go1.9
 
-// Copyright 2018 Microsoft Corporation
+// Copyright 2019 Microsoft Corporation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/profiles/latest/cognitiveservices/computervision/models.go
+++ b/profiles/latest/cognitiveservices/computervision/models.go
@@ -1,6 +1,6 @@
 // +build go1.9
 
-// Copyright 2018 Microsoft Corporation
+// Copyright 2019 Microsoft Corporation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/profiles/latest/cognitiveservices/contentmoderator/contentmoderatorapi/models.go
+++ b/profiles/latest/cognitiveservices/contentmoderator/contentmoderatorapi/models.go
@@ -1,6 +1,6 @@
 // +build go1.9
 
-// Copyright 2018 Microsoft Corporation
+// Copyright 2019 Microsoft Corporation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/profiles/latest/cognitiveservices/contentmoderator/models.go
+++ b/profiles/latest/cognitiveservices/contentmoderator/models.go
@@ -1,6 +1,6 @@
 // +build go1.9
 
-// Copyright 2018 Microsoft Corporation
+// Copyright 2019 Microsoft Corporation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/profiles/latest/cognitiveservices/customimagesearch/customimagesearchapi/models.go
+++ b/profiles/latest/cognitiveservices/customimagesearch/customimagesearchapi/models.go
@@ -1,6 +1,6 @@
 // +build go1.9
 
-// Copyright 2018 Microsoft Corporation
+// Copyright 2019 Microsoft Corporation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/profiles/latest/cognitiveservices/customimagesearch/models.go
+++ b/profiles/latest/cognitiveservices/customimagesearch/models.go
@@ -1,6 +1,6 @@
 // +build go1.9
 
-// Copyright 2018 Microsoft Corporation
+// Copyright 2019 Microsoft Corporation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/profiles/latest/cognitiveservices/customsearch/customsearchapi/models.go
+++ b/profiles/latest/cognitiveservices/customsearch/customsearchapi/models.go
@@ -1,6 +1,6 @@
 // +build go1.9
 
-// Copyright 2018 Microsoft Corporation
+// Copyright 2019 Microsoft Corporation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/profiles/latest/cognitiveservices/customsearch/models.go
+++ b/profiles/latest/cognitiveservices/customsearch/models.go
@@ -1,6 +1,6 @@
 // +build go1.9
 
-// Copyright 2018 Microsoft Corporation
+// Copyright 2019 Microsoft Corporation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/profiles/latest/cognitiveservices/customvision/prediction/models.go
+++ b/profiles/latest/cognitiveservices/customvision/prediction/models.go
@@ -1,6 +1,6 @@
 // +build go1.9
 
-// Copyright 2018 Microsoft Corporation
+// Copyright 2019 Microsoft Corporation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/profiles/latest/cognitiveservices/customvision/prediction/predictionapi/models.go
+++ b/profiles/latest/cognitiveservices/customvision/prediction/predictionapi/models.go
@@ -1,6 +1,6 @@
 // +build go1.9
 
-// Copyright 2018 Microsoft Corporation
+// Copyright 2019 Microsoft Corporation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/profiles/latest/cognitiveservices/customvision/training/models.go
+++ b/profiles/latest/cognitiveservices/customvision/training/models.go
@@ -1,6 +1,6 @@
 // +build go1.9
 
-// Copyright 2018 Microsoft Corporation
+// Copyright 2019 Microsoft Corporation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/profiles/latest/cognitiveservices/customvision/training/trainingapi/models.go
+++ b/profiles/latest/cognitiveservices/customvision/training/trainingapi/models.go
@@ -1,6 +1,6 @@
 // +build go1.9
 
-// Copyright 2018 Microsoft Corporation
+// Copyright 2019 Microsoft Corporation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/profiles/latest/cognitiveservices/entitysearch/entitysearchapi/models.go
+++ b/profiles/latest/cognitiveservices/entitysearch/entitysearchapi/models.go
@@ -1,6 +1,6 @@
 // +build go1.9
 
-// Copyright 2018 Microsoft Corporation
+// Copyright 2019 Microsoft Corporation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/profiles/latest/cognitiveservices/entitysearch/models.go
+++ b/profiles/latest/cognitiveservices/entitysearch/models.go
@@ -1,6 +1,6 @@
 // +build go1.9
 
-// Copyright 2018 Microsoft Corporation
+// Copyright 2019 Microsoft Corporation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/profiles/latest/cognitiveservices/face/faceapi/models.go
+++ b/profiles/latest/cognitiveservices/face/faceapi/models.go
@@ -1,6 +1,6 @@
 // +build go1.9
 
-// Copyright 2018 Microsoft Corporation
+// Copyright 2019 Microsoft Corporation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/profiles/latest/cognitiveservices/face/models.go
+++ b/profiles/latest/cognitiveservices/face/models.go
@@ -1,6 +1,6 @@
 // +build go1.9
 
-// Copyright 2018 Microsoft Corporation
+// Copyright 2019 Microsoft Corporation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/profiles/latest/cognitiveservices/imagesearch/imagesearchapi/models.go
+++ b/profiles/latest/cognitiveservices/imagesearch/imagesearchapi/models.go
@@ -1,6 +1,6 @@
 // +build go1.9
 
-// Copyright 2018 Microsoft Corporation
+// Copyright 2019 Microsoft Corporation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/profiles/latest/cognitiveservices/imagesearch/models.go
+++ b/profiles/latest/cognitiveservices/imagesearch/models.go
@@ -1,6 +1,6 @@
 // +build go1.9
 
-// Copyright 2018 Microsoft Corporation
+// Copyright 2019 Microsoft Corporation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/profiles/latest/cognitiveservices/localsearch/localsearchapi/models.go
+++ b/profiles/latest/cognitiveservices/localsearch/localsearchapi/models.go
@@ -1,6 +1,6 @@
 // +build go1.9
 
-// Copyright 2018 Microsoft Corporation
+// Copyright 2019 Microsoft Corporation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/profiles/latest/cognitiveservices/localsearch/models.go
+++ b/profiles/latest/cognitiveservices/localsearch/models.go
@@ -1,6 +1,6 @@
 // +build go1.9
 
-// Copyright 2018 Microsoft Corporation
+// Copyright 2019 Microsoft Corporation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/profiles/latest/cognitiveservices/luis/authoring/authoringapi/models.go
+++ b/profiles/latest/cognitiveservices/luis/authoring/authoringapi/models.go
@@ -1,6 +1,6 @@
 // +build go1.9
 
-// Copyright 2018 Microsoft Corporation
+// Copyright 2019 Microsoft Corporation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/profiles/latest/cognitiveservices/luis/authoring/models.go
+++ b/profiles/latest/cognitiveservices/luis/authoring/models.go
@@ -1,6 +1,6 @@
 // +build go1.9
 
-// Copyright 2018 Microsoft Corporation
+// Copyright 2019 Microsoft Corporation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/profiles/latest/cognitiveservices/luis/programmatic/models.go
+++ b/profiles/latest/cognitiveservices/luis/programmatic/models.go
@@ -1,6 +1,6 @@
 // +build go1.9
 
-// Copyright 2018 Microsoft Corporation
+// Copyright 2019 Microsoft Corporation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/profiles/latest/cognitiveservices/luis/runtime/models.go
+++ b/profiles/latest/cognitiveservices/luis/runtime/models.go
@@ -1,6 +1,6 @@
 // +build go1.9
 
-// Copyright 2018 Microsoft Corporation
+// Copyright 2019 Microsoft Corporation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/profiles/latest/cognitiveservices/luis/runtime/runtimeapi/models.go
+++ b/profiles/latest/cognitiveservices/luis/runtime/runtimeapi/models.go
@@ -1,6 +1,6 @@
 // +build go1.9
 
-// Copyright 2018 Microsoft Corporation
+// Copyright 2019 Microsoft Corporation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/profiles/latest/cognitiveservices/mgmt/cognitiveservices/cognitiveservicesapi/models.go
+++ b/profiles/latest/cognitiveservices/mgmt/cognitiveservices/cognitiveservicesapi/models.go
@@ -1,6 +1,6 @@
 // +build go1.9
 
-// Copyright 2018 Microsoft Corporation
+// Copyright 2019 Microsoft Corporation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/profiles/latest/cognitiveservices/mgmt/cognitiveservices/models.go
+++ b/profiles/latest/cognitiveservices/mgmt/cognitiveservices/models.go
@@ -1,6 +1,6 @@
 // +build go1.9
 
-// Copyright 2018 Microsoft Corporation
+// Copyright 2019 Microsoft Corporation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/profiles/latest/cognitiveservices/newssearch/models.go
+++ b/profiles/latest/cognitiveservices/newssearch/models.go
@@ -1,6 +1,6 @@
 // +build go1.9
 
-// Copyright 2018 Microsoft Corporation
+// Copyright 2019 Microsoft Corporation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/profiles/latest/cognitiveservices/newssearch/newssearchapi/models.go
+++ b/profiles/latest/cognitiveservices/newssearch/newssearchapi/models.go
@@ -1,6 +1,6 @@
 // +build go1.9
 
-// Copyright 2018 Microsoft Corporation
+// Copyright 2019 Microsoft Corporation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/profiles/latest/cognitiveservices/qnamaker/models.go
+++ b/profiles/latest/cognitiveservices/qnamaker/models.go
@@ -1,6 +1,6 @@
 // +build go1.9
 
-// Copyright 2018 Microsoft Corporation
+// Copyright 2019 Microsoft Corporation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/profiles/latest/cognitiveservices/qnamaker/qnamakerapi/models.go
+++ b/profiles/latest/cognitiveservices/qnamaker/qnamakerapi/models.go
@@ -1,6 +1,6 @@
 // +build go1.9
 
-// Copyright 2018 Microsoft Corporation
+// Copyright 2019 Microsoft Corporation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/profiles/latest/cognitiveservices/spellcheck/models.go
+++ b/profiles/latest/cognitiveservices/spellcheck/models.go
@@ -1,6 +1,6 @@
 // +build go1.9
 
-// Copyright 2018 Microsoft Corporation
+// Copyright 2019 Microsoft Corporation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/profiles/latest/cognitiveservices/spellcheck/spellcheckapi/models.go
+++ b/profiles/latest/cognitiveservices/spellcheck/spellcheckapi/models.go
@@ -1,6 +1,6 @@
 // +build go1.9
 
-// Copyright 2018 Microsoft Corporation
+// Copyright 2019 Microsoft Corporation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/profiles/latest/cognitiveservices/textanalytics/models.go
+++ b/profiles/latest/cognitiveservices/textanalytics/models.go
@@ -1,6 +1,6 @@
 // +build go1.9
 
-// Copyright 2018 Microsoft Corporation
+// Copyright 2019 Microsoft Corporation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/profiles/latest/cognitiveservices/textanalytics/textanalyticsapi/models.go
+++ b/profiles/latest/cognitiveservices/textanalytics/textanalyticsapi/models.go
@@ -1,6 +1,6 @@
 // +build go1.9
 
-// Copyright 2018 Microsoft Corporation
+// Copyright 2019 Microsoft Corporation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/profiles/latest/cognitiveservices/videosearch/models.go
+++ b/profiles/latest/cognitiveservices/videosearch/models.go
@@ -1,6 +1,6 @@
 // +build go1.9
 
-// Copyright 2018 Microsoft Corporation
+// Copyright 2019 Microsoft Corporation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/profiles/latest/cognitiveservices/videosearch/videosearchapi/models.go
+++ b/profiles/latest/cognitiveservices/videosearch/videosearchapi/models.go
@@ -1,6 +1,6 @@
 // +build go1.9
 
-// Copyright 2018 Microsoft Corporation
+// Copyright 2019 Microsoft Corporation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/profiles/latest/cognitiveservices/websearch/models.go
+++ b/profiles/latest/cognitiveservices/websearch/models.go
@@ -1,6 +1,6 @@
 // +build go1.9
 
-// Copyright 2018 Microsoft Corporation
+// Copyright 2019 Microsoft Corporation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/profiles/latest/cognitiveservices/websearch/websearchapi/models.go
+++ b/profiles/latest/cognitiveservices/websearch/websearchapi/models.go
@@ -1,6 +1,6 @@
 // +build go1.9
 
-// Copyright 2018 Microsoft Corporation
+// Copyright 2019 Microsoft Corporation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/profiles/latest/compute/mgmt/compute/computeapi/models.go
+++ b/profiles/latest/compute/mgmt/compute/computeapi/models.go
@@ -1,6 +1,6 @@
 // +build go1.9
 
-// Copyright 2018 Microsoft Corporation
+// Copyright 2019 Microsoft Corporation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/profiles/latest/compute/mgmt/compute/models.go
+++ b/profiles/latest/compute/mgmt/compute/models.go
@@ -1,6 +1,6 @@
 // +build go1.9
 
-// Copyright 2018 Microsoft Corporation
+// Copyright 2019 Microsoft Corporation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/profiles/latest/compute/mgmt/skus/models.go
+++ b/profiles/latest/compute/mgmt/skus/models.go
@@ -1,6 +1,6 @@
 // +build go1.9
 
-// Copyright 2018 Microsoft Corporation
+// Copyright 2019 Microsoft Corporation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/profiles/latest/compute/mgmt/skus/skusapi/models.go
+++ b/profiles/latest/compute/mgmt/skus/skusapi/models.go
@@ -1,6 +1,6 @@
 // +build go1.9
 
-// Copyright 2018 Microsoft Corporation
+// Copyright 2019 Microsoft Corporation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/profiles/latest/consumption/mgmt/consumption/consumptionapi/models.go
+++ b/profiles/latest/consumption/mgmt/consumption/consumptionapi/models.go
@@ -1,6 +1,6 @@
 // +build go1.9
 
-// Copyright 2018 Microsoft Corporation
+// Copyright 2019 Microsoft Corporation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/profiles/latest/consumption/mgmt/consumption/models.go
+++ b/profiles/latest/consumption/mgmt/consumption/models.go
@@ -1,6 +1,6 @@
 // +build go1.9
 
-// Copyright 2018 Microsoft Corporation
+// Copyright 2019 Microsoft Corporation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/profiles/latest/containerinstance/mgmt/containerinstance/containerinstanceapi/models.go
+++ b/profiles/latest/containerinstance/mgmt/containerinstance/containerinstanceapi/models.go
@@ -1,6 +1,6 @@
 // +build go1.9
 
-// Copyright 2018 Microsoft Corporation
+// Copyright 2019 Microsoft Corporation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/profiles/latest/containerinstance/mgmt/containerinstance/models.go
+++ b/profiles/latest/containerinstance/mgmt/containerinstance/models.go
@@ -1,6 +1,6 @@
 // +build go1.9
 
-// Copyright 2018 Microsoft Corporation
+// Copyright 2019 Microsoft Corporation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/profiles/latest/containerregistry/mgmt/containerregistry/containerregistryapi/models.go
+++ b/profiles/latest/containerregistry/mgmt/containerregistry/containerregistryapi/models.go
@@ -1,6 +1,6 @@
 // +build go1.9
 
-// Copyright 2018 Microsoft Corporation
+// Copyright 2019 Microsoft Corporation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/profiles/latest/containerregistry/mgmt/containerregistry/models.go
+++ b/profiles/latest/containerregistry/mgmt/containerregistry/models.go
@@ -1,6 +1,6 @@
 // +build go1.9
 
-// Copyright 2018 Microsoft Corporation
+// Copyright 2019 Microsoft Corporation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/profiles/latest/containerservice/mgmt/containerservice/containerserviceapi/models.go
+++ b/profiles/latest/containerservice/mgmt/containerservice/containerserviceapi/models.go
@@ -1,6 +1,6 @@
 // +build go1.9
 
-// Copyright 2018 Microsoft Corporation
+// Copyright 2019 Microsoft Corporation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/profiles/latest/containerservice/mgmt/containerservice/models.go
+++ b/profiles/latest/containerservice/mgmt/containerservice/models.go
@@ -1,6 +1,6 @@
 // +build go1.9
 
-// Copyright 2018 Microsoft Corporation
+// Copyright 2019 Microsoft Corporation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/profiles/latest/cosmos-db/mgmt/documentdb/documentdbapi/models.go
+++ b/profiles/latest/cosmos-db/mgmt/documentdb/documentdbapi/models.go
@@ -1,6 +1,6 @@
 // +build go1.9
 
-// Copyright 2018 Microsoft Corporation
+// Copyright 2019 Microsoft Corporation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/profiles/latest/cosmos-db/mgmt/documentdb/models.go
+++ b/profiles/latest/cosmos-db/mgmt/documentdb/models.go
@@ -1,6 +1,6 @@
 // +build go1.9
 
-// Copyright 2018 Microsoft Corporation
+// Copyright 2019 Microsoft Corporation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/profiles/latest/costmanagement/mgmt/costmanagement/costmanagementapi/models.go
+++ b/profiles/latest/costmanagement/mgmt/costmanagement/costmanagementapi/models.go
@@ -1,6 +1,6 @@
 // +build go1.9
 
-// Copyright 2018 Microsoft Corporation
+// Copyright 2019 Microsoft Corporation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/profiles/latest/costmanagement/mgmt/costmanagement/models.go
+++ b/profiles/latest/costmanagement/mgmt/costmanagement/models.go
@@ -1,6 +1,6 @@
 // +build go1.9
 
-// Copyright 2018 Microsoft Corporation
+// Copyright 2019 Microsoft Corporation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/profiles/latest/customerinsights/mgmt/customerinsights/customerinsightsapi/models.go
+++ b/profiles/latest/customerinsights/mgmt/customerinsights/customerinsightsapi/models.go
@@ -1,6 +1,6 @@
 // +build go1.9
 
-// Copyright 2018 Microsoft Corporation
+// Copyright 2019 Microsoft Corporation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/profiles/latest/customerinsights/mgmt/customerinsights/models.go
+++ b/profiles/latest/customerinsights/mgmt/customerinsights/models.go
@@ -1,6 +1,6 @@
 // +build go1.9
 
-// Copyright 2018 Microsoft Corporation
+// Copyright 2019 Microsoft Corporation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/profiles/latest/databox/mgmt/databox/databoxapi/models.go
+++ b/profiles/latest/databox/mgmt/databox/databoxapi/models.go
@@ -1,6 +1,6 @@
 // +build go1.9
 
-// Copyright 2018 Microsoft Corporation
+// Copyright 2019 Microsoft Corporation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/profiles/latest/databox/mgmt/databox/models.go
+++ b/profiles/latest/databox/mgmt/databox/models.go
@@ -1,6 +1,6 @@
 // +build go1.9
 
-// Copyright 2018 Microsoft Corporation
+// Copyright 2019 Microsoft Corporation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/profiles/latest/databricks/mgmt/databricks/databricksapi/models.go
+++ b/profiles/latest/databricks/mgmt/databricks/databricksapi/models.go
@@ -1,6 +1,6 @@
 // +build go1.9
 
-// Copyright 2018 Microsoft Corporation
+// Copyright 2019 Microsoft Corporation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/profiles/latest/databricks/mgmt/databricks/models.go
+++ b/profiles/latest/databricks/mgmt/databricks/models.go
@@ -1,6 +1,6 @@
 // +build go1.9
 
-// Copyright 2018 Microsoft Corporation
+// Copyright 2019 Microsoft Corporation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/profiles/latest/datacatalog/mgmt/datacatalog/datacatalogapi/models.go
+++ b/profiles/latest/datacatalog/mgmt/datacatalog/datacatalogapi/models.go
@@ -1,6 +1,6 @@
 // +build go1.9
 
-// Copyright 2018 Microsoft Corporation
+// Copyright 2019 Microsoft Corporation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/profiles/latest/datacatalog/mgmt/datacatalog/models.go
+++ b/profiles/latest/datacatalog/mgmt/datacatalog/models.go
@@ -1,6 +1,6 @@
 // +build go1.9
 
-// Copyright 2018 Microsoft Corporation
+// Copyright 2019 Microsoft Corporation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/profiles/latest/datafactory/mgmt/datafactory/datafactoryapi/models.go
+++ b/profiles/latest/datafactory/mgmt/datafactory/datafactoryapi/models.go
@@ -1,6 +1,6 @@
 // +build go1.9
 
-// Copyright 2018 Microsoft Corporation
+// Copyright 2019 Microsoft Corporation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/profiles/latest/datafactory/mgmt/datafactory/models.go
+++ b/profiles/latest/datafactory/mgmt/datafactory/models.go
@@ -1,6 +1,6 @@
 // +build go1.9
 
-// Copyright 2018 Microsoft Corporation
+// Copyright 2019 Microsoft Corporation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/profiles/latest/datalake/analytics/job/jobapi/models.go
+++ b/profiles/latest/datalake/analytics/job/jobapi/models.go
@@ -1,6 +1,6 @@
 // +build go1.9
 
-// Copyright 2018 Microsoft Corporation
+// Copyright 2019 Microsoft Corporation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/profiles/latest/datalake/analytics/job/models.go
+++ b/profiles/latest/datalake/analytics/job/models.go
@@ -1,6 +1,6 @@
 // +build go1.9
 
-// Copyright 2018 Microsoft Corporation
+// Copyright 2019 Microsoft Corporation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/profiles/latest/datalake/analytics/mgmt/account/accountapi/models.go
+++ b/profiles/latest/datalake/analytics/mgmt/account/accountapi/models.go
@@ -1,6 +1,6 @@
 // +build go1.9
 
-// Copyright 2018 Microsoft Corporation
+// Copyright 2019 Microsoft Corporation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/profiles/latest/datalake/analytics/mgmt/account/models.go
+++ b/profiles/latest/datalake/analytics/mgmt/account/models.go
@@ -1,6 +1,6 @@
 // +build go1.9
 
-// Copyright 2018 Microsoft Corporation
+// Copyright 2019 Microsoft Corporation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/profiles/latest/datalake/store/filesystem/filesystemapi/models.go
+++ b/profiles/latest/datalake/store/filesystem/filesystemapi/models.go
@@ -1,6 +1,6 @@
 // +build go1.9
 
-// Copyright 2018 Microsoft Corporation
+// Copyright 2019 Microsoft Corporation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/profiles/latest/datalake/store/filesystem/models.go
+++ b/profiles/latest/datalake/store/filesystem/models.go
@@ -1,6 +1,6 @@
 // +build go1.9
 
-// Copyright 2018 Microsoft Corporation
+// Copyright 2019 Microsoft Corporation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/profiles/latest/datalake/store/mgmt/account/accountapi/models.go
+++ b/profiles/latest/datalake/store/mgmt/account/accountapi/models.go
@@ -1,6 +1,6 @@
 // +build go1.9
 
-// Copyright 2018 Microsoft Corporation
+// Copyright 2019 Microsoft Corporation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/profiles/latest/datalake/store/mgmt/account/models.go
+++ b/profiles/latest/datalake/store/mgmt/account/models.go
@@ -1,6 +1,6 @@
 // +build go1.9
 
-// Copyright 2018 Microsoft Corporation
+// Copyright 2019 Microsoft Corporation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/profiles/latest/datamigration/mgmt/datamigration/datamigrationapi/models.go
+++ b/profiles/latest/datamigration/mgmt/datamigration/datamigrationapi/models.go
@@ -1,6 +1,6 @@
 // +build go1.9
 
-// Copyright 2018 Microsoft Corporation
+// Copyright 2019 Microsoft Corporation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/profiles/latest/datamigration/mgmt/datamigration/models.go
+++ b/profiles/latest/datamigration/mgmt/datamigration/models.go
@@ -1,6 +1,6 @@
 // +build go1.9
 
-// Copyright 2018 Microsoft Corporation
+// Copyright 2019 Microsoft Corporation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/profiles/latest/devtestlabs/mgmt/dtl/dtlapi/models.go
+++ b/profiles/latest/devtestlabs/mgmt/dtl/dtlapi/models.go
@@ -1,6 +1,6 @@
 // +build go1.9
 
-// Copyright 2018 Microsoft Corporation
+// Copyright 2019 Microsoft Corporation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/profiles/latest/devtestlabs/mgmt/dtl/models.go
+++ b/profiles/latest/devtestlabs/mgmt/dtl/models.go
@@ -1,6 +1,6 @@
 // +build go1.9
 
-// Copyright 2018 Microsoft Corporation
+// Copyright 2019 Microsoft Corporation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/profiles/latest/dns/mgmt/dns/dnsapi/models.go
+++ b/profiles/latest/dns/mgmt/dns/dnsapi/models.go
@@ -1,6 +1,6 @@
 // +build go1.9
 
-// Copyright 2018 Microsoft Corporation
+// Copyright 2019 Microsoft Corporation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/profiles/latest/dns/mgmt/dns/models.go
+++ b/profiles/latest/dns/mgmt/dns/models.go
@@ -1,6 +1,6 @@
 // +build go1.9
 
-// Copyright 2018 Microsoft Corporation
+// Copyright 2019 Microsoft Corporation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/profiles/latest/domainservices/mgmt/aad/aadapi/models.go
+++ b/profiles/latest/domainservices/mgmt/aad/aadapi/models.go
@@ -1,6 +1,6 @@
 // +build go1.9
 
-// Copyright 2018 Microsoft Corporation
+// Copyright 2019 Microsoft Corporation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/profiles/latest/domainservices/mgmt/aad/models.go
+++ b/profiles/latest/domainservices/mgmt/aad/models.go
@@ -1,6 +1,6 @@
 // +build go1.9
 
-// Copyright 2018 Microsoft Corporation
+// Copyright 2019 Microsoft Corporation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/profiles/latest/eventgrid/eventgrid/eventgridapi/models.go
+++ b/profiles/latest/eventgrid/eventgrid/eventgridapi/models.go
@@ -1,6 +1,6 @@
 // +build go1.9
 
-// Copyright 2018 Microsoft Corporation
+// Copyright 2019 Microsoft Corporation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/profiles/latest/eventgrid/eventgrid/models.go
+++ b/profiles/latest/eventgrid/eventgrid/models.go
@@ -1,6 +1,6 @@
 // +build go1.9
 
-// Copyright 2018 Microsoft Corporation
+// Copyright 2019 Microsoft Corporation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/profiles/latest/eventgrid/mgmt/eventgrid/eventgridapi/models.go
+++ b/profiles/latest/eventgrid/mgmt/eventgrid/eventgridapi/models.go
@@ -1,6 +1,6 @@
 // +build go1.9
 
-// Copyright 2018 Microsoft Corporation
+// Copyright 2019 Microsoft Corporation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -19,7 +19,7 @@
 
 package eventgridapi
 
-import original "github.com/Azure/azure-sdk-for-go/services/eventgrid/mgmt/2018-01-01/eventgrid/eventgridapi"
+import original "github.com/Azure/azure-sdk-for-go/services/eventgrid/mgmt/2019-01-01/eventgrid/eventgridapi"
 
 type EventSubscriptionsClientAPI = original.EventSubscriptionsClientAPI
 type OperationsClientAPI = original.OperationsClientAPI

--- a/profiles/latest/eventgrid/mgmt/eventgrid/models.go
+++ b/profiles/latest/eventgrid/mgmt/eventgrid/models.go
@@ -1,6 +1,6 @@
 // +build go1.9
 
-// Copyright 2018 Microsoft Corporation
+// Copyright 2019 Microsoft Corporation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -19,7 +19,7 @@
 
 package eventgrid
 
-import original "github.com/Azure/azure-sdk-for-go/services/eventgrid/mgmt/2018-01-01/eventgrid"
+import original "github.com/Azure/azure-sdk-for-go/services/eventgrid/mgmt/2019-01-01/eventgrid"
 
 const (
 	DefaultBaseURI = original.DefaultBaseURI
@@ -30,18 +30,28 @@ type EndpointType = original.EndpointType
 const (
 	EndpointTypeEventHub                     EndpointType = original.EndpointTypeEventHub
 	EndpointTypeEventSubscriptionDestination EndpointType = original.EndpointTypeEventSubscriptionDestination
+	EndpointTypeHybridConnection             EndpointType = original.EndpointTypeHybridConnection
+	EndpointTypeStorageQueue                 EndpointType = original.EndpointTypeStorageQueue
 	EndpointTypeWebHook                      EndpointType = original.EndpointTypeWebHook
+)
+
+type EndpointTypeBasicDeadLetterDestination = original.EndpointTypeBasicDeadLetterDestination
+
+const (
+	EndpointTypeDeadLetterDestination EndpointTypeBasicDeadLetterDestination = original.EndpointTypeDeadLetterDestination
+	EndpointTypeStorageBlob           EndpointTypeBasicDeadLetterDestination = original.EndpointTypeStorageBlob
 )
 
 type EventSubscriptionProvisioningState = original.EventSubscriptionProvisioningState
 
 const (
-	Canceled  EventSubscriptionProvisioningState = original.Canceled
-	Creating  EventSubscriptionProvisioningState = original.Creating
-	Deleting  EventSubscriptionProvisioningState = original.Deleting
-	Failed    EventSubscriptionProvisioningState = original.Failed
-	Succeeded EventSubscriptionProvisioningState = original.Succeeded
-	Updating  EventSubscriptionProvisioningState = original.Updating
+	AwaitingManualAction EventSubscriptionProvisioningState = original.AwaitingManualAction
+	Canceled             EventSubscriptionProvisioningState = original.Canceled
+	Creating             EventSubscriptionProvisioningState = original.Creating
+	Deleting             EventSubscriptionProvisioningState = original.Deleting
+	Failed               EventSubscriptionProvisioningState = original.Failed
+	Succeeded            EventSubscriptionProvisioningState = original.Succeeded
+	Updating             EventSubscriptionProvisioningState = original.Updating
 )
 
 type ResourceRegionType = original.ResourceRegionType
@@ -74,7 +84,9 @@ const (
 )
 
 type BaseClient = original.BaseClient
+type BasicDeadLetterDestination = original.BasicDeadLetterDestination
 type BasicEventSubscriptionDestination = original.BasicEventSubscriptionDestination
+type DeadLetterDestination = original.DeadLetterDestination
 type EventHubEventSubscriptionDestination = original.EventHubEventSubscriptionDestination
 type EventHubEventSubscriptionDestinationProperties = original.EventHubEventSubscriptionDestinationProperties
 type EventSubscription = original.EventSubscription
@@ -91,11 +103,18 @@ type EventSubscriptionsUpdateFuture = original.EventSubscriptionsUpdateFuture
 type EventType = original.EventType
 type EventTypeProperties = original.EventTypeProperties
 type EventTypesListResult = original.EventTypesListResult
+type HybridConnectionEventSubscriptionDestination = original.HybridConnectionEventSubscriptionDestination
+type HybridConnectionEventSubscriptionDestinationProperties = original.HybridConnectionEventSubscriptionDestinationProperties
 type Operation = original.Operation
 type OperationInfo = original.OperationInfo
 type OperationsClient = original.OperationsClient
 type OperationsListResult = original.OperationsListResult
 type Resource = original.Resource
+type RetryPolicy = original.RetryPolicy
+type StorageBlobDeadLetterDestination = original.StorageBlobDeadLetterDestination
+type StorageBlobDeadLetterDestinationProperties = original.StorageBlobDeadLetterDestinationProperties
+type StorageQueueEventSubscriptionDestination = original.StorageQueueEventSubscriptionDestination
+type StorageQueueEventSubscriptionDestinationProperties = original.StorageQueueEventSubscriptionDestinationProperties
 type Topic = original.Topic
 type TopicProperties = original.TopicProperties
 type TopicRegenerateKeyRequest = original.TopicRegenerateKeyRequest
@@ -143,6 +162,9 @@ func NewTopicsClientWithBaseURI(baseURI string, subscriptionID string) TopicsCli
 }
 func NewWithBaseURI(baseURI string, subscriptionID string) BaseClient {
 	return original.NewWithBaseURI(baseURI, subscriptionID)
+}
+func PossibleEndpointTypeBasicDeadLetterDestinationValues() []EndpointTypeBasicDeadLetterDestination {
+	return original.PossibleEndpointTypeBasicDeadLetterDestinationValues()
 }
 func PossibleEndpointTypeValues() []EndpointType {
 	return original.PossibleEndpointTypeValues()

--- a/profiles/latest/eventhub/mgmt/eventhub/eventhubapi/models.go
+++ b/profiles/latest/eventhub/mgmt/eventhub/eventhubapi/models.go
@@ -1,6 +1,6 @@
 // +build go1.9
 
-// Copyright 2018 Microsoft Corporation
+// Copyright 2019 Microsoft Corporation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/profiles/latest/eventhub/mgmt/eventhub/models.go
+++ b/profiles/latest/eventhub/mgmt/eventhub/models.go
@@ -1,6 +1,6 @@
 // +build go1.9
 
-// Copyright 2018 Microsoft Corporation
+// Copyright 2019 Microsoft Corporation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/profiles/latest/graphrbac/graphrbac/graphrbacapi/models.go
+++ b/profiles/latest/graphrbac/graphrbac/graphrbacapi/models.go
@@ -1,6 +1,6 @@
 // +build go1.9
 
-// Copyright 2018 Microsoft Corporation
+// Copyright 2019 Microsoft Corporation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/profiles/latest/graphrbac/graphrbac/models.go
+++ b/profiles/latest/graphrbac/graphrbac/models.go
@@ -1,6 +1,6 @@
 // +build go1.9
 
-// Copyright 2018 Microsoft Corporation
+// Copyright 2019 Microsoft Corporation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/profiles/latest/iotcentral/mgmt/iotcentral/iotcentralapi/models.go
+++ b/profiles/latest/iotcentral/mgmt/iotcentral/iotcentralapi/models.go
@@ -1,6 +1,6 @@
 // +build go1.9
 
-// Copyright 2018 Microsoft Corporation
+// Copyright 2019 Microsoft Corporation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/profiles/latest/iotcentral/mgmt/iotcentral/models.go
+++ b/profiles/latest/iotcentral/mgmt/iotcentral/models.go
@@ -1,6 +1,6 @@
 // +build go1.9
 
-// Copyright 2018 Microsoft Corporation
+// Copyright 2019 Microsoft Corporation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/profiles/latest/iothub/mgmt/devices/devicesapi/models.go
+++ b/profiles/latest/iothub/mgmt/devices/devicesapi/models.go
@@ -1,6 +1,6 @@
 // +build go1.9
 
-// Copyright 2018 Microsoft Corporation
+// Copyright 2019 Microsoft Corporation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/profiles/latest/iothub/mgmt/devices/models.go
+++ b/profiles/latest/iothub/mgmt/devices/models.go
@@ -1,6 +1,6 @@
 // +build go1.9
 
-// Copyright 2018 Microsoft Corporation
+// Copyright 2019 Microsoft Corporation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/profiles/latest/keyvault/keyvault/keyvaultapi/models.go
+++ b/profiles/latest/keyvault/keyvault/keyvaultapi/models.go
@@ -1,6 +1,6 @@
 // +build go1.9
 
-// Copyright 2018 Microsoft Corporation
+// Copyright 2019 Microsoft Corporation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/profiles/latest/keyvault/keyvault/models.go
+++ b/profiles/latest/keyvault/keyvault/models.go
@@ -1,6 +1,6 @@
 // +build go1.9
 
-// Copyright 2018 Microsoft Corporation
+// Copyright 2019 Microsoft Corporation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/profiles/latest/keyvault/mgmt/keyvault/keyvaultapi/models.go
+++ b/profiles/latest/keyvault/mgmt/keyvault/keyvaultapi/models.go
@@ -1,6 +1,6 @@
 // +build go1.9
 
-// Copyright 2018 Microsoft Corporation
+// Copyright 2019 Microsoft Corporation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/profiles/latest/keyvault/mgmt/keyvault/models.go
+++ b/profiles/latest/keyvault/mgmt/keyvault/models.go
@@ -1,6 +1,6 @@
 // +build go1.9
 
-// Copyright 2018 Microsoft Corporation
+// Copyright 2019 Microsoft Corporation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/profiles/latest/labservices/mgmt/labservices/labservicesapi/models.go
+++ b/profiles/latest/labservices/mgmt/labservices/labservicesapi/models.go
@@ -1,6 +1,6 @@
 // +build go1.9
 
-// Copyright 2018 Microsoft Corporation
+// Copyright 2019 Microsoft Corporation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/profiles/latest/labservices/mgmt/labservices/models.go
+++ b/profiles/latest/labservices/mgmt/labservices/models.go
@@ -1,6 +1,6 @@
 // +build go1.9
 
-// Copyright 2018 Microsoft Corporation
+// Copyright 2019 Microsoft Corporation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/profiles/latest/logic/mgmt/logic/logicapi/models.go
+++ b/profiles/latest/logic/mgmt/logic/logicapi/models.go
@@ -1,6 +1,6 @@
 // +build go1.9
 
-// Copyright 2018 Microsoft Corporation
+// Copyright 2019 Microsoft Corporation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/profiles/latest/logic/mgmt/logic/models.go
+++ b/profiles/latest/logic/mgmt/logic/models.go
@@ -1,6 +1,6 @@
 // +build go1.9
 
-// Copyright 2018 Microsoft Corporation
+// Copyright 2019 Microsoft Corporation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/profiles/latest/machinelearning/mgmt/webservices/models.go
+++ b/profiles/latest/machinelearning/mgmt/webservices/models.go
@@ -1,6 +1,6 @@
 // +build go1.9
 
-// Copyright 2018 Microsoft Corporation
+// Copyright 2019 Microsoft Corporation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/profiles/latest/machinelearning/mgmt/webservices/webservicesapi/models.go
+++ b/profiles/latest/machinelearning/mgmt/webservices/webservicesapi/models.go
@@ -1,6 +1,6 @@
 // +build go1.9
 
-// Copyright 2018 Microsoft Corporation
+// Copyright 2019 Microsoft Corporation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/profiles/latest/machinelearning/mgmt/workspaces/models.go
+++ b/profiles/latest/machinelearning/mgmt/workspaces/models.go
@@ -1,6 +1,6 @@
 // +build go1.9
 
-// Copyright 2018 Microsoft Corporation
+// Copyright 2019 Microsoft Corporation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/profiles/latest/machinelearning/mgmt/workspaces/workspacesapi/models.go
+++ b/profiles/latest/machinelearning/mgmt/workspaces/workspacesapi/models.go
@@ -1,6 +1,6 @@
 // +build go1.9
 
-// Copyright 2018 Microsoft Corporation
+// Copyright 2019 Microsoft Corporation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/profiles/latest/managementpartner/mgmt/managementpartner/models.go
+++ b/profiles/latest/managementpartner/mgmt/managementpartner/models.go
@@ -1,6 +1,6 @@
 // +build go1.9
 
-// Copyright 2018 Microsoft Corporation
+// Copyright 2019 Microsoft Corporation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/profiles/latest/maps/mgmt/maps/mapsapi/models.go
+++ b/profiles/latest/maps/mgmt/maps/mapsapi/models.go
@@ -1,6 +1,6 @@
 // +build go1.9
 
-// Copyright 2018 Microsoft Corporation
+// Copyright 2019 Microsoft Corporation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/profiles/latest/maps/mgmt/maps/models.go
+++ b/profiles/latest/maps/mgmt/maps/models.go
@@ -1,6 +1,6 @@
 // +build go1.9
 
-// Copyright 2018 Microsoft Corporation
+// Copyright 2019 Microsoft Corporation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/profiles/latest/marketplaceordering/mgmt/marketplaceordering/marketplaceorderingapi/models.go
+++ b/profiles/latest/marketplaceordering/mgmt/marketplaceordering/marketplaceorderingapi/models.go
@@ -1,6 +1,6 @@
 // +build go1.9
 
-// Copyright 2018 Microsoft Corporation
+// Copyright 2019 Microsoft Corporation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/profiles/latest/marketplaceordering/mgmt/marketplaceordering/models.go
+++ b/profiles/latest/marketplaceordering/mgmt/marketplaceordering/models.go
@@ -1,6 +1,6 @@
 // +build go1.9
 
-// Copyright 2018 Microsoft Corporation
+// Copyright 2019 Microsoft Corporation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/profiles/latest/mediaservices/mgmt/media/mediaapi/models.go
+++ b/profiles/latest/mediaservices/mgmt/media/mediaapi/models.go
@@ -1,6 +1,6 @@
 // +build go1.9
 
-// Copyright 2018 Microsoft Corporation
+// Copyright 2019 Microsoft Corporation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/profiles/latest/mediaservices/mgmt/media/models.go
+++ b/profiles/latest/mediaservices/mgmt/media/models.go
@@ -1,6 +1,6 @@
 // +build go1.9
 
-// Copyright 2018 Microsoft Corporation
+// Copyright 2019 Microsoft Corporation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/profiles/latest/migrate/mgmt/migrate/migrateapi/models.go
+++ b/profiles/latest/migrate/mgmt/migrate/migrateapi/models.go
@@ -1,6 +1,6 @@
 // +build go1.9
 
-// Copyright 2018 Microsoft Corporation
+// Copyright 2019 Microsoft Corporation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/profiles/latest/migrate/mgmt/migrate/models.go
+++ b/profiles/latest/migrate/mgmt/migrate/models.go
@@ -1,6 +1,6 @@
 // +build go1.9
 
-// Copyright 2018 Microsoft Corporation
+// Copyright 2019 Microsoft Corporation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/profiles/latest/mobileengagement/mgmt/mobileengagement/models.go
+++ b/profiles/latest/mobileengagement/mgmt/mobileengagement/models.go
@@ -1,6 +1,6 @@
 // +build go1.9
 
-// Copyright 2018 Microsoft Corporation
+// Copyright 2019 Microsoft Corporation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/profiles/latest/monitor/mgmt/insights/models.go
+++ b/profiles/latest/monitor/mgmt/insights/models.go
@@ -1,6 +1,6 @@
 // +build go1.9
 
-// Copyright 2018 Microsoft Corporation
+// Copyright 2019 Microsoft Corporation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/profiles/latest/msi/mgmt/msi/models.go
+++ b/profiles/latest/msi/mgmt/msi/models.go
@@ -1,6 +1,6 @@
 // +build go1.9
 
-// Copyright 2018 Microsoft Corporation
+// Copyright 2019 Microsoft Corporation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/profiles/latest/msi/mgmt/msi/msiapi/models.go
+++ b/profiles/latest/msi/mgmt/msi/msiapi/models.go
@@ -1,6 +1,6 @@
 // +build go1.9
 
-// Copyright 2018 Microsoft Corporation
+// Copyright 2019 Microsoft Corporation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/profiles/latest/mysql/mgmt/mysql/models.go
+++ b/profiles/latest/mysql/mgmt/mysql/models.go
@@ -1,6 +1,6 @@
 // +build go1.9
 
-// Copyright 2018 Microsoft Corporation
+// Copyright 2019 Microsoft Corporation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/profiles/latest/mysql/mgmt/mysql/mysqlapi/models.go
+++ b/profiles/latest/mysql/mgmt/mysql/mysqlapi/models.go
@@ -1,6 +1,6 @@
 // +build go1.9
 
-// Copyright 2018 Microsoft Corporation
+// Copyright 2019 Microsoft Corporation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/profiles/latest/network/mgmt/network/models.go
+++ b/profiles/latest/network/mgmt/network/models.go
@@ -1,6 +1,6 @@
 // +build go1.9
 
-// Copyright 2018 Microsoft Corporation
+// Copyright 2019 Microsoft Corporation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/profiles/latest/network/mgmt/network/networkapi/models.go
+++ b/profiles/latest/network/mgmt/network/networkapi/models.go
@@ -1,6 +1,6 @@
 // +build go1.9
 
-// Copyright 2018 Microsoft Corporation
+// Copyright 2019 Microsoft Corporation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/profiles/latest/notificationhubs/mgmt/notificationhubs/models.go
+++ b/profiles/latest/notificationhubs/mgmt/notificationhubs/models.go
@@ -1,6 +1,6 @@
 // +build go1.9
 
-// Copyright 2018 Microsoft Corporation
+// Copyright 2019 Microsoft Corporation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/profiles/latest/notificationhubs/mgmt/notificationhubs/notificationhubsapi/models.go
+++ b/profiles/latest/notificationhubs/mgmt/notificationhubs/notificationhubsapi/models.go
@@ -1,6 +1,6 @@
 // +build go1.9
 
-// Copyright 2018 Microsoft Corporation
+// Copyright 2019 Microsoft Corporation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/profiles/latest/operationalinsights/mgmt/operationalinsights/models.go
+++ b/profiles/latest/operationalinsights/mgmt/operationalinsights/models.go
@@ -1,6 +1,6 @@
 // +build go1.9
 
-// Copyright 2018 Microsoft Corporation
+// Copyright 2019 Microsoft Corporation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/profiles/latest/operationalinsights/mgmt/operationalinsights/operationalinsightsapi/models.go
+++ b/profiles/latest/operationalinsights/mgmt/operationalinsights/operationalinsightsapi/models.go
@@ -1,6 +1,6 @@
 // +build go1.9
 
-// Copyright 2018 Microsoft Corporation
+// Copyright 2019 Microsoft Corporation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/profiles/latest/operationalinsights/operationalinsights/models.go
+++ b/profiles/latest/operationalinsights/operationalinsights/models.go
@@ -1,6 +1,6 @@
 // +build go1.9
 
-// Copyright 2018 Microsoft Corporation
+// Copyright 2019 Microsoft Corporation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/profiles/latest/operationalinsights/operationalinsights/operationalinsightsapi/models.go
+++ b/profiles/latest/operationalinsights/operationalinsights/operationalinsightsapi/models.go
@@ -1,6 +1,6 @@
 // +build go1.9
 
-// Copyright 2018 Microsoft Corporation
+// Copyright 2019 Microsoft Corporation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/profiles/latest/policyinsights/mgmt/policyinsights/models.go
+++ b/profiles/latest/policyinsights/mgmt/policyinsights/models.go
@@ -1,6 +1,6 @@
 // +build go1.9
 
-// Copyright 2018 Microsoft Corporation
+// Copyright 2019 Microsoft Corporation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/profiles/latest/policyinsights/mgmt/policyinsights/policyinsightsapi/models.go
+++ b/profiles/latest/policyinsights/mgmt/policyinsights/policyinsightsapi/models.go
@@ -1,6 +1,6 @@
 // +build go1.9
 
-// Copyright 2018 Microsoft Corporation
+// Copyright 2019 Microsoft Corporation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/profiles/latest/postgresql/mgmt/postgresql/models.go
+++ b/profiles/latest/postgresql/mgmt/postgresql/models.go
@@ -1,6 +1,6 @@
 // +build go1.9
 
-// Copyright 2018 Microsoft Corporation
+// Copyright 2019 Microsoft Corporation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/profiles/latest/postgresql/mgmt/postgresql/postgresqlapi/models.go
+++ b/profiles/latest/postgresql/mgmt/postgresql/postgresqlapi/models.go
@@ -1,6 +1,6 @@
 // +build go1.9
 
-// Copyright 2018 Microsoft Corporation
+// Copyright 2019 Microsoft Corporation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/profiles/latest/powerbidedicated/mgmt/powerbidedicated/models.go
+++ b/profiles/latest/powerbidedicated/mgmt/powerbidedicated/models.go
@@ -1,6 +1,6 @@
 // +build go1.9
 
-// Copyright 2018 Microsoft Corporation
+// Copyright 2019 Microsoft Corporation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/profiles/latest/powerbidedicated/mgmt/powerbidedicated/powerbidedicatedapi/models.go
+++ b/profiles/latest/powerbidedicated/mgmt/powerbidedicated/powerbidedicatedapi/models.go
@@ -1,6 +1,6 @@
 // +build go1.9
 
-// Copyright 2018 Microsoft Corporation
+// Copyright 2019 Microsoft Corporation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/profiles/latest/powerbiembedded/mgmt/powerbiembedded/models.go
+++ b/profiles/latest/powerbiembedded/mgmt/powerbiembedded/models.go
@@ -1,6 +1,6 @@
 // +build go1.9
 
-// Copyright 2018 Microsoft Corporation
+// Copyright 2019 Microsoft Corporation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/profiles/latest/powerbiembedded/mgmt/powerbiembedded/powerbiembeddedapi/models.go
+++ b/profiles/latest/powerbiembedded/mgmt/powerbiembedded/powerbiembeddedapi/models.go
@@ -1,6 +1,6 @@
 // +build go1.9
 
-// Copyright 2018 Microsoft Corporation
+// Copyright 2019 Microsoft Corporation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/profiles/latest/provisioningservices/mgmt/iothub/iothubapi/models.go
+++ b/profiles/latest/provisioningservices/mgmt/iothub/iothubapi/models.go
@@ -1,6 +1,6 @@
 // +build go1.9
 
-// Copyright 2018 Microsoft Corporation
+// Copyright 2019 Microsoft Corporation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/profiles/latest/provisioningservices/mgmt/iothub/models.go
+++ b/profiles/latest/provisioningservices/mgmt/iothub/models.go
@@ -1,6 +1,6 @@
 // +build go1.9
 
-// Copyright 2018 Microsoft Corporation
+// Copyright 2019 Microsoft Corporation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/profiles/latest/recoveryservices/mgmt/backup/backupapi/models.go
+++ b/profiles/latest/recoveryservices/mgmt/backup/backupapi/models.go
@@ -1,6 +1,6 @@
 // +build go1.9
 
-// Copyright 2018 Microsoft Corporation
+// Copyright 2019 Microsoft Corporation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/profiles/latest/recoveryservices/mgmt/backup/models.go
+++ b/profiles/latest/recoveryservices/mgmt/backup/models.go
@@ -1,6 +1,6 @@
 // +build go1.9
 
-// Copyright 2018 Microsoft Corporation
+// Copyright 2019 Microsoft Corporation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/profiles/latest/recoveryservices/mgmt/recoveryservices/models.go
+++ b/profiles/latest/recoveryservices/mgmt/recoveryservices/models.go
@@ -1,6 +1,6 @@
 // +build go1.9
 
-// Copyright 2018 Microsoft Corporation
+// Copyright 2019 Microsoft Corporation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/profiles/latest/recoveryservices/mgmt/recoveryservices/recoveryservicesapi/models.go
+++ b/profiles/latest/recoveryservices/mgmt/recoveryservices/recoveryservicesapi/models.go
@@ -1,6 +1,6 @@
 // +build go1.9
 
-// Copyright 2018 Microsoft Corporation
+// Copyright 2019 Microsoft Corporation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/profiles/latest/recoveryservices/mgmt/siterecovery/models.go
+++ b/profiles/latest/recoveryservices/mgmt/siterecovery/models.go
@@ -1,6 +1,6 @@
 // +build go1.9
 
-// Copyright 2018 Microsoft Corporation
+// Copyright 2019 Microsoft Corporation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/profiles/latest/recoveryservices/mgmt/siterecovery/siterecoveryapi/models.go
+++ b/profiles/latest/recoveryservices/mgmt/siterecovery/siterecoveryapi/models.go
@@ -1,6 +1,6 @@
 // +build go1.9
 
-// Copyright 2018 Microsoft Corporation
+// Copyright 2019 Microsoft Corporation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/profiles/latest/redis/mgmt/redis/models.go
+++ b/profiles/latest/redis/mgmt/redis/models.go
@@ -1,6 +1,6 @@
 // +build go1.9
 
-// Copyright 2018 Microsoft Corporation
+// Copyright 2019 Microsoft Corporation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/profiles/latest/redis/mgmt/redis/redisapi/models.go
+++ b/profiles/latest/redis/mgmt/redis/redisapi/models.go
@@ -1,6 +1,6 @@
 // +build go1.9
 
-// Copyright 2018 Microsoft Corporation
+// Copyright 2019 Microsoft Corporation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/profiles/latest/relay/mgmt/relay/models.go
+++ b/profiles/latest/relay/mgmt/relay/models.go
@@ -1,6 +1,6 @@
 // +build go1.9
 
-// Copyright 2018 Microsoft Corporation
+// Copyright 2019 Microsoft Corporation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/profiles/latest/relay/mgmt/relay/relayapi/models.go
+++ b/profiles/latest/relay/mgmt/relay/relayapi/models.go
@@ -1,6 +1,6 @@
 // +build go1.9
 
-// Copyright 2018 Microsoft Corporation
+// Copyright 2019 Microsoft Corporation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/profiles/latest/reservations/mgmt/reservations/models.go
+++ b/profiles/latest/reservations/mgmt/reservations/models.go
@@ -1,6 +1,6 @@
 // +build go1.9
 
-// Copyright 2018 Microsoft Corporation
+// Copyright 2019 Microsoft Corporation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/profiles/latest/reservations/mgmt/reservations/reservationsapi/models.go
+++ b/profiles/latest/reservations/mgmt/reservations/reservationsapi/models.go
@@ -1,6 +1,6 @@
 // +build go1.9
 
-// Copyright 2018 Microsoft Corporation
+// Copyright 2019 Microsoft Corporation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/profiles/latest/resourcehealth/mgmt/resourcehealth/models.go
+++ b/profiles/latest/resourcehealth/mgmt/resourcehealth/models.go
@@ -1,6 +1,6 @@
 // +build go1.9
 
-// Copyright 2018 Microsoft Corporation
+// Copyright 2019 Microsoft Corporation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/profiles/latest/resourcehealth/mgmt/resourcehealth/resourcehealthapi/models.go
+++ b/profiles/latest/resourcehealth/mgmt/resourcehealth/resourcehealthapi/models.go
@@ -1,6 +1,6 @@
 // +build go1.9
 
-// Copyright 2018 Microsoft Corporation
+// Copyright 2019 Microsoft Corporation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/profiles/latest/resources/mgmt/features/featuresapi/models.go
+++ b/profiles/latest/resources/mgmt/features/featuresapi/models.go
@@ -1,6 +1,6 @@
 // +build go1.9
 
-// Copyright 2018 Microsoft Corporation
+// Copyright 2019 Microsoft Corporation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/profiles/latest/resources/mgmt/features/models.go
+++ b/profiles/latest/resources/mgmt/features/models.go
@@ -1,6 +1,6 @@
 // +build go1.9
 
-// Copyright 2018 Microsoft Corporation
+// Copyright 2019 Microsoft Corporation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/profiles/latest/resources/mgmt/links/linksapi/models.go
+++ b/profiles/latest/resources/mgmt/links/linksapi/models.go
@@ -1,6 +1,6 @@
 // +build go1.9
 
-// Copyright 2018 Microsoft Corporation
+// Copyright 2019 Microsoft Corporation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/profiles/latest/resources/mgmt/links/models.go
+++ b/profiles/latest/resources/mgmt/links/models.go
@@ -1,6 +1,6 @@
 // +build go1.9
 
-// Copyright 2018 Microsoft Corporation
+// Copyright 2019 Microsoft Corporation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/profiles/latest/resources/mgmt/locks/locksapi/models.go
+++ b/profiles/latest/resources/mgmt/locks/locksapi/models.go
@@ -1,6 +1,6 @@
 // +build go1.9
 
-// Copyright 2018 Microsoft Corporation
+// Copyright 2019 Microsoft Corporation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/profiles/latest/resources/mgmt/locks/models.go
+++ b/profiles/latest/resources/mgmt/locks/models.go
@@ -1,6 +1,6 @@
 // +build go1.9
 
-// Copyright 2018 Microsoft Corporation
+// Copyright 2019 Microsoft Corporation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/profiles/latest/resources/mgmt/managedapplications/managedapplicationsapi/models.go
+++ b/profiles/latest/resources/mgmt/managedapplications/managedapplicationsapi/models.go
@@ -1,6 +1,6 @@
 // +build go1.9
 
-// Copyright 2018 Microsoft Corporation
+// Copyright 2019 Microsoft Corporation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/profiles/latest/resources/mgmt/managedapplications/models.go
+++ b/profiles/latest/resources/mgmt/managedapplications/models.go
@@ -1,6 +1,6 @@
 // +build go1.9
 
-// Copyright 2018 Microsoft Corporation
+// Copyright 2019 Microsoft Corporation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/profiles/latest/resources/mgmt/policy/models.go
+++ b/profiles/latest/resources/mgmt/policy/models.go
@@ -1,6 +1,6 @@
 // +build go1.9
 
-// Copyright 2018 Microsoft Corporation
+// Copyright 2019 Microsoft Corporation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/profiles/latest/resources/mgmt/policy/policyapi/models.go
+++ b/profiles/latest/resources/mgmt/policy/policyapi/models.go
@@ -1,6 +1,6 @@
 // +build go1.9
 
-// Copyright 2018 Microsoft Corporation
+// Copyright 2019 Microsoft Corporation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/profiles/latest/resources/mgmt/resources/models.go
+++ b/profiles/latest/resources/mgmt/resources/models.go
@@ -1,6 +1,6 @@
 // +build go1.9
 
-// Copyright 2018 Microsoft Corporation
+// Copyright 2019 Microsoft Corporation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/profiles/latest/resources/mgmt/resources/resourcesapi/models.go
+++ b/profiles/latest/resources/mgmt/resources/resourcesapi/models.go
@@ -1,6 +1,6 @@
 // +build go1.9
 
-// Copyright 2018 Microsoft Corporation
+// Copyright 2019 Microsoft Corporation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/profiles/latest/resources/mgmt/subscriptions/models.go
+++ b/profiles/latest/resources/mgmt/subscriptions/models.go
@@ -1,6 +1,6 @@
 // +build go1.9
 
-// Copyright 2018 Microsoft Corporation
+// Copyright 2019 Microsoft Corporation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/profiles/latest/resources/mgmt/subscriptions/subscriptionsapi/models.go
+++ b/profiles/latest/resources/mgmt/subscriptions/subscriptionsapi/models.go
@@ -1,6 +1,6 @@
 // +build go1.9
 
-// Copyright 2018 Microsoft Corporation
+// Copyright 2019 Microsoft Corporation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/profiles/latest/scheduler/mgmt/scheduler/models.go
+++ b/profiles/latest/scheduler/mgmt/scheduler/models.go
@@ -1,6 +1,6 @@
 // +build go1.9
 
-// Copyright 2018 Microsoft Corporation
+// Copyright 2019 Microsoft Corporation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/profiles/latest/scheduler/mgmt/scheduler/schedulerapi/models.go
+++ b/profiles/latest/scheduler/mgmt/scheduler/schedulerapi/models.go
@@ -1,6 +1,6 @@
 // +build go1.9
 
-// Copyright 2018 Microsoft Corporation
+// Copyright 2019 Microsoft Corporation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/profiles/latest/search/mgmt/search/models.go
+++ b/profiles/latest/search/mgmt/search/models.go
@@ -1,6 +1,6 @@
 // +build go1.9
 
-// Copyright 2018 Microsoft Corporation
+// Copyright 2019 Microsoft Corporation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/profiles/latest/search/mgmt/search/searchapi/models.go
+++ b/profiles/latest/search/mgmt/search/searchapi/models.go
@@ -1,6 +1,6 @@
 // +build go1.9
 
-// Copyright 2018 Microsoft Corporation
+// Copyright 2019 Microsoft Corporation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/profiles/latest/servicebus/mgmt/servicebus/models.go
+++ b/profiles/latest/servicebus/mgmt/servicebus/models.go
@@ -1,6 +1,6 @@
 // +build go1.9
 
-// Copyright 2018 Microsoft Corporation
+// Copyright 2019 Microsoft Corporation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/profiles/latest/servicebus/mgmt/servicebus/servicebusapi/models.go
+++ b/profiles/latest/servicebus/mgmt/servicebus/servicebusapi/models.go
@@ -1,6 +1,6 @@
 // +build go1.9
 
-// Copyright 2018 Microsoft Corporation
+// Copyright 2019 Microsoft Corporation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/profiles/latest/servicefabric/mgmt/servicefabric/models.go
+++ b/profiles/latest/servicefabric/mgmt/servicefabric/models.go
@@ -1,6 +1,6 @@
 // +build go1.9
 
-// Copyright 2018 Microsoft Corporation
+// Copyright 2019 Microsoft Corporation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/profiles/latest/servicefabric/servicefabric/models.go
+++ b/profiles/latest/servicefabric/servicefabric/models.go
@@ -1,6 +1,6 @@
 // +build go1.9
 
-// Copyright 2018 Microsoft Corporation
+// Copyright 2019 Microsoft Corporation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/profiles/latest/servicefabric/servicefabric/servicefabricapi/models.go
+++ b/profiles/latest/servicefabric/servicefabric/servicefabricapi/models.go
@@ -1,6 +1,6 @@
 // +build go1.9
 
-// Copyright 2018 Microsoft Corporation
+// Copyright 2019 Microsoft Corporation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/profiles/latest/signalr/mgmt/signalr/models.go
+++ b/profiles/latest/signalr/mgmt/signalr/models.go
@@ -1,6 +1,6 @@
 // +build go1.9
 
-// Copyright 2018 Microsoft Corporation
+// Copyright 2019 Microsoft Corporation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/profiles/latest/signalr/mgmt/signalr/signalrapi/models.go
+++ b/profiles/latest/signalr/mgmt/signalr/signalrapi/models.go
@@ -1,6 +1,6 @@
 // +build go1.9
 
-// Copyright 2018 Microsoft Corporation
+// Copyright 2019 Microsoft Corporation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/profiles/latest/sql/mgmt/sql/models.go
+++ b/profiles/latest/sql/mgmt/sql/models.go
@@ -1,6 +1,6 @@
 // +build go1.9
 
-// Copyright 2018 Microsoft Corporation
+// Copyright 2019 Microsoft Corporation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/profiles/latest/sql/mgmt/sql/sqlapi/models.go
+++ b/profiles/latest/sql/mgmt/sql/sqlapi/models.go
@@ -1,6 +1,6 @@
 // +build go1.9
 
-// Copyright 2018 Microsoft Corporation
+// Copyright 2019 Microsoft Corporation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/profiles/latest/stable/storage/datalake/storagedatalake/models.go
+++ b/profiles/latest/stable/storage/datalake/storagedatalake/models.go
@@ -1,6 +1,6 @@
 // +build go1.9
 
-// Copyright 2018 Microsoft Corporation
+// Copyright 2019 Microsoft Corporation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/profiles/latest/stable/storage/datalake/storagedatalake/storagedatalakeapi/models.go
+++ b/profiles/latest/stable/storage/datalake/storagedatalake/storagedatalakeapi/models.go
@@ -1,6 +1,6 @@
 // +build go1.9
 
-// Copyright 2018 Microsoft Corporation
+// Copyright 2019 Microsoft Corporation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/profiles/latest/storage/datalake/storagedatalake/models.go
+++ b/profiles/latest/storage/datalake/storagedatalake/models.go
@@ -1,6 +1,6 @@
 // +build go1.9
 
-// Copyright 2018 Microsoft Corporation
+// Copyright 2019 Microsoft Corporation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/profiles/latest/storage/datalake/storagedatalake/storagedatalakeapi/models.go
+++ b/profiles/latest/storage/datalake/storagedatalake/storagedatalakeapi/models.go
@@ -1,6 +1,6 @@
 // +build go1.9
 
-// Copyright 2018 Microsoft Corporation
+// Copyright 2019 Microsoft Corporation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/profiles/latest/storage/mgmt/storage/models.go
+++ b/profiles/latest/storage/mgmt/storage/models.go
@@ -1,6 +1,6 @@
 // +build go1.9
 
-// Copyright 2018 Microsoft Corporation
+// Copyright 2019 Microsoft Corporation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/profiles/latest/storage/mgmt/storage/storageapi/models.go
+++ b/profiles/latest/storage/mgmt/storage/storageapi/models.go
@@ -1,6 +1,6 @@
 // +build go1.9
 
-// Copyright 2018 Microsoft Corporation
+// Copyright 2019 Microsoft Corporation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/profiles/latest/storageimportexport/mgmt/storageimportexport/models.go
+++ b/profiles/latest/storageimportexport/mgmt/storageimportexport/models.go
@@ -1,6 +1,6 @@
 // +build go1.9
 
-// Copyright 2018 Microsoft Corporation
+// Copyright 2019 Microsoft Corporation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/profiles/latest/storageimportexport/mgmt/storageimportexport/storageimportexportapi/models.go
+++ b/profiles/latest/storageimportexport/mgmt/storageimportexport/storageimportexportapi/models.go
@@ -1,6 +1,6 @@
 // +build go1.9
 
-// Copyright 2018 Microsoft Corporation
+// Copyright 2019 Microsoft Corporation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/profiles/latest/storagesync/mgmt/storagesync/models.go
+++ b/profiles/latest/storagesync/mgmt/storagesync/models.go
@@ -1,6 +1,6 @@
 // +build go1.9
 
-// Copyright 2018 Microsoft Corporation
+// Copyright 2019 Microsoft Corporation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/profiles/latest/storagesync/mgmt/storagesync/storagesyncapi/models.go
+++ b/profiles/latest/storagesync/mgmt/storagesync/storagesyncapi/models.go
@@ -1,6 +1,6 @@
 // +build go1.9
 
-// Copyright 2018 Microsoft Corporation
+// Copyright 2019 Microsoft Corporation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/profiles/latest/storsimple1200series/mgmt/storsimple/models.go
+++ b/profiles/latest/storsimple1200series/mgmt/storsimple/models.go
@@ -1,6 +1,6 @@
 // +build go1.9
 
-// Copyright 2018 Microsoft Corporation
+// Copyright 2019 Microsoft Corporation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/profiles/latest/storsimple1200series/mgmt/storsimple/storsimpleapi/models.go
+++ b/profiles/latest/storsimple1200series/mgmt/storsimple/storsimpleapi/models.go
@@ -1,6 +1,6 @@
 // +build go1.9
 
-// Copyright 2018 Microsoft Corporation
+// Copyright 2019 Microsoft Corporation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/profiles/latest/storsimple8000series/mgmt/storsimple/models.go
+++ b/profiles/latest/storsimple8000series/mgmt/storsimple/models.go
@@ -1,6 +1,6 @@
 // +build go1.9
 
-// Copyright 2018 Microsoft Corporation
+// Copyright 2019 Microsoft Corporation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/profiles/latest/storsimple8000series/mgmt/storsimple/storsimpleapi/models.go
+++ b/profiles/latest/storsimple8000series/mgmt/storsimple/storsimpleapi/models.go
@@ -1,6 +1,6 @@
 // +build go1.9
 
-// Copyright 2018 Microsoft Corporation
+// Copyright 2019 Microsoft Corporation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/profiles/latest/streamanalytics/mgmt/streamanalytics/models.go
+++ b/profiles/latest/streamanalytics/mgmt/streamanalytics/models.go
@@ -1,6 +1,6 @@
 // +build go1.9
 
-// Copyright 2018 Microsoft Corporation
+// Copyright 2019 Microsoft Corporation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/profiles/latest/streamanalytics/mgmt/streamanalytics/streamanalyticsapi/models.go
+++ b/profiles/latest/streamanalytics/mgmt/streamanalytics/streamanalyticsapi/models.go
@@ -1,6 +1,6 @@
 // +build go1.9
 
-// Copyright 2018 Microsoft Corporation
+// Copyright 2019 Microsoft Corporation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/profiles/latest/timeseriesinsights/mgmt/timeseriesinsights/models.go
+++ b/profiles/latest/timeseriesinsights/mgmt/timeseriesinsights/models.go
@@ -1,6 +1,6 @@
 // +build go1.9
 
-// Copyright 2018 Microsoft Corporation
+// Copyright 2019 Microsoft Corporation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/profiles/latest/timeseriesinsights/mgmt/timeseriesinsights/timeseriesinsightsapi/models.go
+++ b/profiles/latest/timeseriesinsights/mgmt/timeseriesinsights/timeseriesinsightsapi/models.go
@@ -1,6 +1,6 @@
 // +build go1.9
 
-// Copyright 2018 Microsoft Corporation
+// Copyright 2019 Microsoft Corporation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/profiles/latest/trafficmanager/mgmt/trafficmanager/models.go
+++ b/profiles/latest/trafficmanager/mgmt/trafficmanager/models.go
@@ -1,6 +1,6 @@
 // +build go1.9
 
-// Copyright 2018 Microsoft Corporation
+// Copyright 2019 Microsoft Corporation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/profiles/latest/trafficmanager/mgmt/trafficmanager/trafficmanagerapi/models.go
+++ b/profiles/latest/trafficmanager/mgmt/trafficmanager/trafficmanagerapi/models.go
@@ -1,6 +1,6 @@
 // +build go1.9
 
-// Copyright 2018 Microsoft Corporation
+// Copyright 2019 Microsoft Corporation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/profiles/latest/web/mgmt/web/models.go
+++ b/profiles/latest/web/mgmt/web/models.go
@@ -1,6 +1,6 @@
 // +build go1.9
 
-// Copyright 2018 Microsoft Corporation
+// Copyright 2019 Microsoft Corporation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/profiles/latest/web/mgmt/web/webapi/models.go
+++ b/profiles/latest/web/mgmt/web/webapi/models.go
@@ -1,6 +1,6 @@
 // +build go1.9
 
-// Copyright 2018 Microsoft Corporation
+// Copyright 2019 Microsoft Corporation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/profiles/preview/adhybridhealthservice/mgmt/adhybridhealthservice/adhybridhealthserviceapi/models.go
+++ b/profiles/preview/adhybridhealthservice/mgmt/adhybridhealthservice/adhybridhealthserviceapi/models.go
@@ -1,6 +1,6 @@
 // +build go1.9
 
-// Copyright 2018 Microsoft Corporation
+// Copyright 2019 Microsoft Corporation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/profiles/preview/adhybridhealthservice/mgmt/adhybridhealthservice/models.go
+++ b/profiles/preview/adhybridhealthservice/mgmt/adhybridhealthservice/models.go
@@ -1,6 +1,6 @@
 // +build go1.9
 
-// Copyright 2018 Microsoft Corporation
+// Copyright 2019 Microsoft Corporation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/profiles/preview/advisor/mgmt/advisor/advisorapi/models.go
+++ b/profiles/preview/advisor/mgmt/advisor/advisorapi/models.go
@@ -1,6 +1,6 @@
 // +build go1.9
 
-// Copyright 2018 Microsoft Corporation
+// Copyright 2019 Microsoft Corporation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/profiles/preview/advisor/mgmt/advisor/models.go
+++ b/profiles/preview/advisor/mgmt/advisor/models.go
@@ -1,6 +1,6 @@
 // +build go1.9
 
-// Copyright 2018 Microsoft Corporation
+// Copyright 2019 Microsoft Corporation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/profiles/preview/alertsmanagement/mgmt/alertsmanagement/alertsmanagementapi/models.go
+++ b/profiles/preview/alertsmanagement/mgmt/alertsmanagement/alertsmanagementapi/models.go
@@ -1,6 +1,6 @@
 // +build go1.9
 
-// Copyright 2018 Microsoft Corporation
+// Copyright 2019 Microsoft Corporation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/profiles/preview/alertsmanagement/mgmt/alertsmanagement/models.go
+++ b/profiles/preview/alertsmanagement/mgmt/alertsmanagement/models.go
@@ -1,6 +1,6 @@
 // +build go1.9
 
-// Copyright 2018 Microsoft Corporation
+// Copyright 2019 Microsoft Corporation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/profiles/preview/analysisservices/mgmt/analysisservices/analysisservicesapi/models.go
+++ b/profiles/preview/analysisservices/mgmt/analysisservices/analysisservicesapi/models.go
@@ -1,6 +1,6 @@
 // +build go1.9
 
-// Copyright 2018 Microsoft Corporation
+// Copyright 2019 Microsoft Corporation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/profiles/preview/analysisservices/mgmt/analysisservices/models.go
+++ b/profiles/preview/analysisservices/mgmt/analysisservices/models.go
@@ -1,6 +1,6 @@
 // +build go1.9
 
-// Copyright 2018 Microsoft Corporation
+// Copyright 2019 Microsoft Corporation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/profiles/preview/apimanagement/mgmt/apimanagement/apimanagementapi/models.go
+++ b/profiles/preview/apimanagement/mgmt/apimanagement/apimanagementapi/models.go
@@ -1,6 +1,6 @@
 // +build go1.9
 
-// Copyright 2018 Microsoft Corporation
+// Copyright 2019 Microsoft Corporation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/profiles/preview/apimanagement/mgmt/apimanagement/models.go
+++ b/profiles/preview/apimanagement/mgmt/apimanagement/models.go
@@ -1,6 +1,6 @@
 // +build go1.9
 
-// Copyright 2018 Microsoft Corporation
+// Copyright 2019 Microsoft Corporation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/profiles/preview/appinsights/insights/models.go
+++ b/profiles/preview/appinsights/insights/models.go
@@ -1,6 +1,6 @@
 // +build go1.9
 
-// Copyright 2018 Microsoft Corporation
+// Copyright 2019 Microsoft Corporation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/profiles/preview/appinsights/mgmt/insights/insightsapi/models.go
+++ b/profiles/preview/appinsights/mgmt/insights/insightsapi/models.go
@@ -1,6 +1,6 @@
 // +build go1.9
 
-// Copyright 2018 Microsoft Corporation
+// Copyright 2019 Microsoft Corporation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/profiles/preview/appinsights/mgmt/insights/models.go
+++ b/profiles/preview/appinsights/mgmt/insights/models.go
@@ -1,6 +1,6 @@
 // +build go1.9
 
-// Copyright 2018 Microsoft Corporation
+// Copyright 2019 Microsoft Corporation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/profiles/preview/authorization/mgmt/authorization/authorizationapi/models.go
+++ b/profiles/preview/authorization/mgmt/authorization/authorizationapi/models.go
@@ -1,6 +1,6 @@
 // +build go1.9
 
-// Copyright 2018 Microsoft Corporation
+// Copyright 2019 Microsoft Corporation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/profiles/preview/authorization/mgmt/authorization/models.go
+++ b/profiles/preview/authorization/mgmt/authorization/models.go
@@ -1,6 +1,6 @@
 // +build go1.9
 
-// Copyright 2018 Microsoft Corporation
+// Copyright 2019 Microsoft Corporation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/profiles/preview/automation/mgmt/automation/automationapi/models.go
+++ b/profiles/preview/automation/mgmt/automation/automationapi/models.go
@@ -1,6 +1,6 @@
 // +build go1.9
 
-// Copyright 2018 Microsoft Corporation
+// Copyright 2019 Microsoft Corporation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/profiles/preview/automation/mgmt/automation/models.go
+++ b/profiles/preview/automation/mgmt/automation/models.go
@@ -1,6 +1,6 @@
 // +build go1.9
 
-// Copyright 2018 Microsoft Corporation
+// Copyright 2019 Microsoft Corporation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/profiles/preview/azsadmin/mgmt/fabric/models.go
+++ b/profiles/preview/azsadmin/mgmt/fabric/models.go
@@ -1,6 +1,6 @@
 // +build go1.9
 
-// Copyright 2018 Microsoft Corporation
+// Copyright 2019 Microsoft Corporation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/profiles/preview/azsadmin/mgmt/infrastructureinsights/models.go
+++ b/profiles/preview/azsadmin/mgmt/infrastructureinsights/models.go
@@ -1,6 +1,6 @@
 // +build go1.9
 
-// Copyright 2018 Microsoft Corporation
+// Copyright 2019 Microsoft Corporation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/profiles/preview/azurestack/mgmt/azurestack/azurestackapi/models.go
+++ b/profiles/preview/azurestack/mgmt/azurestack/azurestackapi/models.go
@@ -1,6 +1,6 @@
 // +build go1.9
 
-// Copyright 2018 Microsoft Corporation
+// Copyright 2019 Microsoft Corporation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/profiles/preview/azurestack/mgmt/azurestack/models.go
+++ b/profiles/preview/azurestack/mgmt/azurestack/models.go
@@ -1,6 +1,6 @@
 // +build go1.9
 
-// Copyright 2018 Microsoft Corporation
+// Copyright 2019 Microsoft Corporation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/profiles/preview/batch/batch/batchapi/models.go
+++ b/profiles/preview/batch/batch/batchapi/models.go
@@ -1,6 +1,6 @@
 // +build go1.9
 
-// Copyright 2018 Microsoft Corporation
+// Copyright 2019 Microsoft Corporation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/profiles/preview/batch/batch/models.go
+++ b/profiles/preview/batch/batch/models.go
@@ -1,6 +1,6 @@
 // +build go1.9
 
-// Copyright 2018 Microsoft Corporation
+// Copyright 2019 Microsoft Corporation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/profiles/preview/batch/mgmt/batch/batchapi/models.go
+++ b/profiles/preview/batch/mgmt/batch/batchapi/models.go
@@ -1,6 +1,6 @@
 // +build go1.9
 
-// Copyright 2018 Microsoft Corporation
+// Copyright 2019 Microsoft Corporation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/profiles/preview/batch/mgmt/batch/models.go
+++ b/profiles/preview/batch/mgmt/batch/models.go
@@ -1,6 +1,6 @@
 // +build go1.9
 
-// Copyright 2018 Microsoft Corporation
+// Copyright 2019 Microsoft Corporation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/profiles/preview/batchai/mgmt/batchai/batchaiapi/models.go
+++ b/profiles/preview/batchai/mgmt/batchai/batchaiapi/models.go
@@ -1,6 +1,6 @@
 // +build go1.9
 
-// Copyright 2018 Microsoft Corporation
+// Copyright 2019 Microsoft Corporation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/profiles/preview/batchai/mgmt/batchai/models.go
+++ b/profiles/preview/batchai/mgmt/batchai/models.go
@@ -1,6 +1,6 @@
 // +build go1.9
 
-// Copyright 2018 Microsoft Corporation
+// Copyright 2019 Microsoft Corporation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/profiles/preview/cdn/mgmt/cdn/cdnapi/models.go
+++ b/profiles/preview/cdn/mgmt/cdn/cdnapi/models.go
@@ -1,6 +1,6 @@
 // +build go1.9
 
-// Copyright 2018 Microsoft Corporation
+// Copyright 2019 Microsoft Corporation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/profiles/preview/cdn/mgmt/cdn/models.go
+++ b/profiles/preview/cdn/mgmt/cdn/models.go
@@ -1,6 +1,6 @@
 // +build go1.9
 
-// Copyright 2018 Microsoft Corporation
+// Copyright 2019 Microsoft Corporation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/profiles/preview/cognitiveservices/autosuggest/autosuggestapi/models.go
+++ b/profiles/preview/cognitiveservices/autosuggest/autosuggestapi/models.go
@@ -1,6 +1,6 @@
 // +build go1.9
 
-// Copyright 2018 Microsoft Corporation
+// Copyright 2019 Microsoft Corporation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/profiles/preview/cognitiveservices/autosuggest/models.go
+++ b/profiles/preview/cognitiveservices/autosuggest/models.go
@@ -1,6 +1,6 @@
 // +build go1.9
 
-// Copyright 2018 Microsoft Corporation
+// Copyright 2019 Microsoft Corporation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/profiles/preview/cognitiveservices/computervision/computervisionapi/models.go
+++ b/profiles/preview/cognitiveservices/computervision/computervisionapi/models.go
@@ -1,6 +1,6 @@
 // +build go1.9
 
-// Copyright 2018 Microsoft Corporation
+// Copyright 2019 Microsoft Corporation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/profiles/preview/cognitiveservices/computervision/models.go
+++ b/profiles/preview/cognitiveservices/computervision/models.go
@@ -1,6 +1,6 @@
 // +build go1.9
 
-// Copyright 2018 Microsoft Corporation
+// Copyright 2019 Microsoft Corporation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/profiles/preview/cognitiveservices/contentmoderator/contentmoderatorapi/models.go
+++ b/profiles/preview/cognitiveservices/contentmoderator/contentmoderatorapi/models.go
@@ -1,6 +1,6 @@
 // +build go1.9
 
-// Copyright 2018 Microsoft Corporation
+// Copyright 2019 Microsoft Corporation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/profiles/preview/cognitiveservices/contentmoderator/models.go
+++ b/profiles/preview/cognitiveservices/contentmoderator/models.go
@@ -1,6 +1,6 @@
 // +build go1.9
 
-// Copyright 2018 Microsoft Corporation
+// Copyright 2019 Microsoft Corporation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/profiles/preview/cognitiveservices/customimagesearch/customimagesearchapi/models.go
+++ b/profiles/preview/cognitiveservices/customimagesearch/customimagesearchapi/models.go
@@ -1,6 +1,6 @@
 // +build go1.9
 
-// Copyright 2018 Microsoft Corporation
+// Copyright 2019 Microsoft Corporation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/profiles/preview/cognitiveservices/customimagesearch/models.go
+++ b/profiles/preview/cognitiveservices/customimagesearch/models.go
@@ -1,6 +1,6 @@
 // +build go1.9
 
-// Copyright 2018 Microsoft Corporation
+// Copyright 2019 Microsoft Corporation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/profiles/preview/cognitiveservices/customsearch/customsearchapi/models.go
+++ b/profiles/preview/cognitiveservices/customsearch/customsearchapi/models.go
@@ -1,6 +1,6 @@
 // +build go1.9
 
-// Copyright 2018 Microsoft Corporation
+// Copyright 2019 Microsoft Corporation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/profiles/preview/cognitiveservices/customsearch/models.go
+++ b/profiles/preview/cognitiveservices/customsearch/models.go
@@ -1,6 +1,6 @@
 // +build go1.9
 
-// Copyright 2018 Microsoft Corporation
+// Copyright 2019 Microsoft Corporation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/profiles/preview/cognitiveservices/customvision/prediction/models.go
+++ b/profiles/preview/cognitiveservices/customvision/prediction/models.go
@@ -1,6 +1,6 @@
 // +build go1.9
 
-// Copyright 2018 Microsoft Corporation
+// Copyright 2019 Microsoft Corporation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/profiles/preview/cognitiveservices/customvision/prediction/predictionapi/models.go
+++ b/profiles/preview/cognitiveservices/customvision/prediction/predictionapi/models.go
@@ -1,6 +1,6 @@
 // +build go1.9
 
-// Copyright 2018 Microsoft Corporation
+// Copyright 2019 Microsoft Corporation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/profiles/preview/cognitiveservices/customvision/training/models.go
+++ b/profiles/preview/cognitiveservices/customvision/training/models.go
@@ -1,6 +1,6 @@
 // +build go1.9
 
-// Copyright 2018 Microsoft Corporation
+// Copyright 2019 Microsoft Corporation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/profiles/preview/cognitiveservices/customvision/training/trainingapi/models.go
+++ b/profiles/preview/cognitiveservices/customvision/training/trainingapi/models.go
@@ -1,6 +1,6 @@
 // +build go1.9
 
-// Copyright 2018 Microsoft Corporation
+// Copyright 2019 Microsoft Corporation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/profiles/preview/cognitiveservices/entitysearch/entitysearchapi/models.go
+++ b/profiles/preview/cognitiveservices/entitysearch/entitysearchapi/models.go
@@ -1,6 +1,6 @@
 // +build go1.9
 
-// Copyright 2018 Microsoft Corporation
+// Copyright 2019 Microsoft Corporation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/profiles/preview/cognitiveservices/entitysearch/models.go
+++ b/profiles/preview/cognitiveservices/entitysearch/models.go
@@ -1,6 +1,6 @@
 // +build go1.9
 
-// Copyright 2018 Microsoft Corporation
+// Copyright 2019 Microsoft Corporation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/profiles/preview/cognitiveservices/face/faceapi/models.go
+++ b/profiles/preview/cognitiveservices/face/faceapi/models.go
@@ -1,6 +1,6 @@
 // +build go1.9
 
-// Copyright 2018 Microsoft Corporation
+// Copyright 2019 Microsoft Corporation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/profiles/preview/cognitiveservices/face/models.go
+++ b/profiles/preview/cognitiveservices/face/models.go
@@ -1,6 +1,6 @@
 // +build go1.9
 
-// Copyright 2018 Microsoft Corporation
+// Copyright 2019 Microsoft Corporation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/profiles/preview/cognitiveservices/imagesearch/imagesearchapi/models.go
+++ b/profiles/preview/cognitiveservices/imagesearch/imagesearchapi/models.go
@@ -1,6 +1,6 @@
 // +build go1.9
 
-// Copyright 2018 Microsoft Corporation
+// Copyright 2019 Microsoft Corporation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/profiles/preview/cognitiveservices/imagesearch/models.go
+++ b/profiles/preview/cognitiveservices/imagesearch/models.go
@@ -1,6 +1,6 @@
 // +build go1.9
 
-// Copyright 2018 Microsoft Corporation
+// Copyright 2019 Microsoft Corporation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/profiles/preview/cognitiveservices/localsearch/localsearchapi/models.go
+++ b/profiles/preview/cognitiveservices/localsearch/localsearchapi/models.go
@@ -1,6 +1,6 @@
 // +build go1.9
 
-// Copyright 2018 Microsoft Corporation
+// Copyright 2019 Microsoft Corporation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/profiles/preview/cognitiveservices/localsearch/models.go
+++ b/profiles/preview/cognitiveservices/localsearch/models.go
@@ -1,6 +1,6 @@
 // +build go1.9
 
-// Copyright 2018 Microsoft Corporation
+// Copyright 2019 Microsoft Corporation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/profiles/preview/cognitiveservices/luis/authoring/authoringapi/models.go
+++ b/profiles/preview/cognitiveservices/luis/authoring/authoringapi/models.go
@@ -1,6 +1,6 @@
 // +build go1.9
 
-// Copyright 2018 Microsoft Corporation
+// Copyright 2019 Microsoft Corporation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/profiles/preview/cognitiveservices/luis/authoring/models.go
+++ b/profiles/preview/cognitiveservices/luis/authoring/models.go
@@ -1,6 +1,6 @@
 // +build go1.9
 
-// Copyright 2018 Microsoft Corporation
+// Copyright 2019 Microsoft Corporation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/profiles/preview/cognitiveservices/luis/programmatic/models.go
+++ b/profiles/preview/cognitiveservices/luis/programmatic/models.go
@@ -1,6 +1,6 @@
 // +build go1.9
 
-// Copyright 2018 Microsoft Corporation
+// Copyright 2019 Microsoft Corporation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/profiles/preview/cognitiveservices/luis/runtime/models.go
+++ b/profiles/preview/cognitiveservices/luis/runtime/models.go
@@ -1,6 +1,6 @@
 // +build go1.9
 
-// Copyright 2018 Microsoft Corporation
+// Copyright 2019 Microsoft Corporation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/profiles/preview/cognitiveservices/luis/runtime/runtimeapi/models.go
+++ b/profiles/preview/cognitiveservices/luis/runtime/runtimeapi/models.go
@@ -1,6 +1,6 @@
 // +build go1.9
 
-// Copyright 2018 Microsoft Corporation
+// Copyright 2019 Microsoft Corporation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/profiles/preview/cognitiveservices/mgmt/cognitiveservices/cognitiveservicesapi/models.go
+++ b/profiles/preview/cognitiveservices/mgmt/cognitiveservices/cognitiveservicesapi/models.go
@@ -1,6 +1,6 @@
 // +build go1.9
 
-// Copyright 2018 Microsoft Corporation
+// Copyright 2019 Microsoft Corporation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/profiles/preview/cognitiveservices/mgmt/cognitiveservices/models.go
+++ b/profiles/preview/cognitiveservices/mgmt/cognitiveservices/models.go
@@ -1,6 +1,6 @@
 // +build go1.9
 
-// Copyright 2018 Microsoft Corporation
+// Copyright 2019 Microsoft Corporation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/profiles/preview/cognitiveservices/newssearch/models.go
+++ b/profiles/preview/cognitiveservices/newssearch/models.go
@@ -1,6 +1,6 @@
 // +build go1.9
 
-// Copyright 2018 Microsoft Corporation
+// Copyright 2019 Microsoft Corporation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/profiles/preview/cognitiveservices/newssearch/newssearchapi/models.go
+++ b/profiles/preview/cognitiveservices/newssearch/newssearchapi/models.go
@@ -1,6 +1,6 @@
 // +build go1.9
 
-// Copyright 2018 Microsoft Corporation
+// Copyright 2019 Microsoft Corporation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/profiles/preview/cognitiveservices/qnamaker/models.go
+++ b/profiles/preview/cognitiveservices/qnamaker/models.go
@@ -1,6 +1,6 @@
 // +build go1.9
 
-// Copyright 2018 Microsoft Corporation
+// Copyright 2019 Microsoft Corporation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/profiles/preview/cognitiveservices/qnamaker/qnamakerapi/models.go
+++ b/profiles/preview/cognitiveservices/qnamaker/qnamakerapi/models.go
@@ -1,6 +1,6 @@
 // +build go1.9
 
-// Copyright 2018 Microsoft Corporation
+// Copyright 2019 Microsoft Corporation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/profiles/preview/cognitiveservices/spellcheck/models.go
+++ b/profiles/preview/cognitiveservices/spellcheck/models.go
@@ -1,6 +1,6 @@
 // +build go1.9
 
-// Copyright 2018 Microsoft Corporation
+// Copyright 2019 Microsoft Corporation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/profiles/preview/cognitiveservices/spellcheck/spellcheckapi/models.go
+++ b/profiles/preview/cognitiveservices/spellcheck/spellcheckapi/models.go
@@ -1,6 +1,6 @@
 // +build go1.9
 
-// Copyright 2018 Microsoft Corporation
+// Copyright 2019 Microsoft Corporation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/profiles/preview/cognitiveservices/textanalytics/models.go
+++ b/profiles/preview/cognitiveservices/textanalytics/models.go
@@ -1,6 +1,6 @@
 // +build go1.9
 
-// Copyright 2018 Microsoft Corporation
+// Copyright 2019 Microsoft Corporation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/profiles/preview/cognitiveservices/textanalytics/textanalyticsapi/models.go
+++ b/profiles/preview/cognitiveservices/textanalytics/textanalyticsapi/models.go
@@ -1,6 +1,6 @@
 // +build go1.9
 
-// Copyright 2018 Microsoft Corporation
+// Copyright 2019 Microsoft Corporation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/profiles/preview/cognitiveservices/videosearch/models.go
+++ b/profiles/preview/cognitiveservices/videosearch/models.go
@@ -1,6 +1,6 @@
 // +build go1.9
 
-// Copyright 2018 Microsoft Corporation
+// Copyright 2019 Microsoft Corporation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/profiles/preview/cognitiveservices/videosearch/videosearchapi/models.go
+++ b/profiles/preview/cognitiveservices/videosearch/videosearchapi/models.go
@@ -1,6 +1,6 @@
 // +build go1.9
 
-// Copyright 2018 Microsoft Corporation
+// Copyright 2019 Microsoft Corporation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/profiles/preview/cognitiveservices/websearch/models.go
+++ b/profiles/preview/cognitiveservices/websearch/models.go
@@ -1,6 +1,6 @@
 // +build go1.9
 
-// Copyright 2018 Microsoft Corporation
+// Copyright 2019 Microsoft Corporation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/profiles/preview/cognitiveservices/websearch/websearchapi/models.go
+++ b/profiles/preview/cognitiveservices/websearch/websearchapi/models.go
@@ -1,6 +1,6 @@
 // +build go1.9
 
-// Copyright 2018 Microsoft Corporation
+// Copyright 2019 Microsoft Corporation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/profiles/preview/compute/mgmt/compute/computeapi/models.go
+++ b/profiles/preview/compute/mgmt/compute/computeapi/models.go
@@ -1,6 +1,6 @@
 // +build go1.9
 
-// Copyright 2018 Microsoft Corporation
+// Copyright 2019 Microsoft Corporation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/profiles/preview/compute/mgmt/compute/models.go
+++ b/profiles/preview/compute/mgmt/compute/models.go
@@ -1,6 +1,6 @@
 // +build go1.9
 
-// Copyright 2018 Microsoft Corporation
+// Copyright 2019 Microsoft Corporation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/profiles/preview/compute/mgmt/skus/models.go
+++ b/profiles/preview/compute/mgmt/skus/models.go
@@ -1,6 +1,6 @@
 // +build go1.9
 
-// Copyright 2018 Microsoft Corporation
+// Copyright 2019 Microsoft Corporation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/profiles/preview/compute/mgmt/skus/skusapi/models.go
+++ b/profiles/preview/compute/mgmt/skus/skusapi/models.go
@@ -1,6 +1,6 @@
 // +build go1.9
 
-// Copyright 2018 Microsoft Corporation
+// Copyright 2019 Microsoft Corporation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/profiles/preview/consumption/mgmt/consumption/consumptionapi/models.go
+++ b/profiles/preview/consumption/mgmt/consumption/consumptionapi/models.go
@@ -1,6 +1,6 @@
 // +build go1.9
 
-// Copyright 2018 Microsoft Corporation
+// Copyright 2019 Microsoft Corporation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/profiles/preview/consumption/mgmt/consumption/models.go
+++ b/profiles/preview/consumption/mgmt/consumption/models.go
@@ -1,6 +1,6 @@
 // +build go1.9
 
-// Copyright 2018 Microsoft Corporation
+// Copyright 2019 Microsoft Corporation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/profiles/preview/containerinstance/mgmt/containerinstance/containerinstanceapi/models.go
+++ b/profiles/preview/containerinstance/mgmt/containerinstance/containerinstanceapi/models.go
@@ -1,6 +1,6 @@
 // +build go1.9
 
-// Copyright 2018 Microsoft Corporation
+// Copyright 2019 Microsoft Corporation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/profiles/preview/containerinstance/mgmt/containerinstance/models.go
+++ b/profiles/preview/containerinstance/mgmt/containerinstance/models.go
@@ -1,6 +1,6 @@
 // +build go1.9
 
-// Copyright 2018 Microsoft Corporation
+// Copyright 2019 Microsoft Corporation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/profiles/preview/containerregistry/mgmt/containerregistry/containerregistryapi/models.go
+++ b/profiles/preview/containerregistry/mgmt/containerregistry/containerregistryapi/models.go
@@ -1,6 +1,6 @@
 // +build go1.9
 
-// Copyright 2018 Microsoft Corporation
+// Copyright 2019 Microsoft Corporation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/profiles/preview/containerregistry/mgmt/containerregistry/models.go
+++ b/profiles/preview/containerregistry/mgmt/containerregistry/models.go
@@ -1,6 +1,6 @@
 // +build go1.9
 
-// Copyright 2018 Microsoft Corporation
+// Copyright 2019 Microsoft Corporation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/profiles/preview/containerservice/mgmt/containerservice/containerserviceapi/models.go
+++ b/profiles/preview/containerservice/mgmt/containerservice/containerserviceapi/models.go
@@ -1,6 +1,6 @@
 // +build go1.9
 
-// Copyright 2018 Microsoft Corporation
+// Copyright 2019 Microsoft Corporation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/profiles/preview/containerservice/mgmt/containerservice/models.go
+++ b/profiles/preview/containerservice/mgmt/containerservice/models.go
@@ -1,6 +1,6 @@
 // +build go1.9
 
-// Copyright 2018 Microsoft Corporation
+// Copyright 2019 Microsoft Corporation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/profiles/preview/cosmos-db/mgmt/documentdb/documentdbapi/models.go
+++ b/profiles/preview/cosmos-db/mgmt/documentdb/documentdbapi/models.go
@@ -1,6 +1,6 @@
 // +build go1.9
 
-// Copyright 2018 Microsoft Corporation
+// Copyright 2019 Microsoft Corporation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/profiles/preview/cosmos-db/mgmt/documentdb/models.go
+++ b/profiles/preview/cosmos-db/mgmt/documentdb/models.go
@@ -1,6 +1,6 @@
 // +build go1.9
 
-// Copyright 2018 Microsoft Corporation
+// Copyright 2019 Microsoft Corporation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/profiles/preview/costmanagement/mgmt/costmanagement/costmanagementapi/models.go
+++ b/profiles/preview/costmanagement/mgmt/costmanagement/costmanagementapi/models.go
@@ -1,6 +1,6 @@
 // +build go1.9
 
-// Copyright 2018 Microsoft Corporation
+// Copyright 2019 Microsoft Corporation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/profiles/preview/costmanagement/mgmt/costmanagement/models.go
+++ b/profiles/preview/costmanagement/mgmt/costmanagement/models.go
@@ -1,6 +1,6 @@
 // +build go1.9
 
-// Copyright 2018 Microsoft Corporation
+// Copyright 2019 Microsoft Corporation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/profiles/preview/customerinsights/mgmt/customerinsights/customerinsightsapi/models.go
+++ b/profiles/preview/customerinsights/mgmt/customerinsights/customerinsightsapi/models.go
@@ -1,6 +1,6 @@
 // +build go1.9
 
-// Copyright 2018 Microsoft Corporation
+// Copyright 2019 Microsoft Corporation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/profiles/preview/customerinsights/mgmt/customerinsights/models.go
+++ b/profiles/preview/customerinsights/mgmt/customerinsights/models.go
@@ -1,6 +1,6 @@
 // +build go1.9
 
-// Copyright 2018 Microsoft Corporation
+// Copyright 2019 Microsoft Corporation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/profiles/preview/databox/mgmt/databox/databoxapi/models.go
+++ b/profiles/preview/databox/mgmt/databox/databoxapi/models.go
@@ -1,6 +1,6 @@
 // +build go1.9
 
-// Copyright 2018 Microsoft Corporation
+// Copyright 2019 Microsoft Corporation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/profiles/preview/databox/mgmt/databox/models.go
+++ b/profiles/preview/databox/mgmt/databox/models.go
@@ -1,6 +1,6 @@
 // +build go1.9
 
-// Copyright 2018 Microsoft Corporation
+// Copyright 2019 Microsoft Corporation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/profiles/preview/databricks/mgmt/databricks/databricksapi/models.go
+++ b/profiles/preview/databricks/mgmt/databricks/databricksapi/models.go
@@ -1,6 +1,6 @@
 // +build go1.9
 
-// Copyright 2018 Microsoft Corporation
+// Copyright 2019 Microsoft Corporation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/profiles/preview/databricks/mgmt/databricks/models.go
+++ b/profiles/preview/databricks/mgmt/databricks/models.go
@@ -1,6 +1,6 @@
 // +build go1.9
 
-// Copyright 2018 Microsoft Corporation
+// Copyright 2019 Microsoft Corporation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/profiles/preview/datacatalog/mgmt/datacatalog/datacatalogapi/models.go
+++ b/profiles/preview/datacatalog/mgmt/datacatalog/datacatalogapi/models.go
@@ -1,6 +1,6 @@
 // +build go1.9
 
-// Copyright 2018 Microsoft Corporation
+// Copyright 2019 Microsoft Corporation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/profiles/preview/datacatalog/mgmt/datacatalog/models.go
+++ b/profiles/preview/datacatalog/mgmt/datacatalog/models.go
@@ -1,6 +1,6 @@
 // +build go1.9
 
-// Copyright 2018 Microsoft Corporation
+// Copyright 2019 Microsoft Corporation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/profiles/preview/datafactory/mgmt/datafactory/datafactoryapi/models.go
+++ b/profiles/preview/datafactory/mgmt/datafactory/datafactoryapi/models.go
@@ -1,6 +1,6 @@
 // +build go1.9
 
-// Copyright 2018 Microsoft Corporation
+// Copyright 2019 Microsoft Corporation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/profiles/preview/datafactory/mgmt/datafactory/models.go
+++ b/profiles/preview/datafactory/mgmt/datafactory/models.go
@@ -1,6 +1,6 @@
 // +build go1.9
 
-// Copyright 2018 Microsoft Corporation
+// Copyright 2019 Microsoft Corporation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/profiles/preview/datalake/analytics/catalog/catalogapi/models.go
+++ b/profiles/preview/datalake/analytics/catalog/catalogapi/models.go
@@ -1,6 +1,6 @@
 // +build go1.9
 
-// Copyright 2018 Microsoft Corporation
+// Copyright 2019 Microsoft Corporation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/profiles/preview/datalake/analytics/catalog/models.go
+++ b/profiles/preview/datalake/analytics/catalog/models.go
@@ -1,6 +1,6 @@
 // +build go1.9
 
-// Copyright 2018 Microsoft Corporation
+// Copyright 2019 Microsoft Corporation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/profiles/preview/datalake/analytics/job/jobapi/models.go
+++ b/profiles/preview/datalake/analytics/job/jobapi/models.go
@@ -1,6 +1,6 @@
 // +build go1.9
 
-// Copyright 2018 Microsoft Corporation
+// Copyright 2019 Microsoft Corporation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/profiles/preview/datalake/analytics/job/models.go
+++ b/profiles/preview/datalake/analytics/job/models.go
@@ -1,6 +1,6 @@
 // +build go1.9
 
-// Copyright 2018 Microsoft Corporation
+// Copyright 2019 Microsoft Corporation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/profiles/preview/datalake/analytics/mgmt/account/accountapi/models.go
+++ b/profiles/preview/datalake/analytics/mgmt/account/accountapi/models.go
@@ -1,6 +1,6 @@
 // +build go1.9
 
-// Copyright 2018 Microsoft Corporation
+// Copyright 2019 Microsoft Corporation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/profiles/preview/datalake/analytics/mgmt/account/models.go
+++ b/profiles/preview/datalake/analytics/mgmt/account/models.go
@@ -1,6 +1,6 @@
 // +build go1.9
 
-// Copyright 2018 Microsoft Corporation
+// Copyright 2019 Microsoft Corporation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/profiles/preview/datalake/store/filesystem/filesystemapi/models.go
+++ b/profiles/preview/datalake/store/filesystem/filesystemapi/models.go
@@ -1,6 +1,6 @@
 // +build go1.9
 
-// Copyright 2018 Microsoft Corporation
+// Copyright 2019 Microsoft Corporation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/profiles/preview/datalake/store/filesystem/models.go
+++ b/profiles/preview/datalake/store/filesystem/models.go
@@ -1,6 +1,6 @@
 // +build go1.9
 
-// Copyright 2018 Microsoft Corporation
+// Copyright 2019 Microsoft Corporation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/profiles/preview/datalake/store/mgmt/account/accountapi/models.go
+++ b/profiles/preview/datalake/store/mgmt/account/accountapi/models.go
@@ -1,6 +1,6 @@
 // +build go1.9
 
-// Copyright 2018 Microsoft Corporation
+// Copyright 2019 Microsoft Corporation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/profiles/preview/datalake/store/mgmt/account/models.go
+++ b/profiles/preview/datalake/store/mgmt/account/models.go
@@ -1,6 +1,6 @@
 // +build go1.9
 
-// Copyright 2018 Microsoft Corporation
+// Copyright 2019 Microsoft Corporation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/profiles/preview/datamigration/mgmt/datamigration/datamigrationapi/models.go
+++ b/profiles/preview/datamigration/mgmt/datamigration/datamigrationapi/models.go
@@ -1,6 +1,6 @@
 // +build go1.9
 
-// Copyright 2018 Microsoft Corporation
+// Copyright 2019 Microsoft Corporation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/profiles/preview/datamigration/mgmt/datamigration/models.go
+++ b/profiles/preview/datamigration/mgmt/datamigration/models.go
@@ -1,6 +1,6 @@
 // +build go1.9
 
-// Copyright 2018 Microsoft Corporation
+// Copyright 2019 Microsoft Corporation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/profiles/preview/devtestlabs/mgmt/dtl/dtlapi/models.go
+++ b/profiles/preview/devtestlabs/mgmt/dtl/dtlapi/models.go
@@ -1,6 +1,6 @@
 // +build go1.9
 
-// Copyright 2018 Microsoft Corporation
+// Copyright 2019 Microsoft Corporation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/profiles/preview/devtestlabs/mgmt/dtl/models.go
+++ b/profiles/preview/devtestlabs/mgmt/dtl/models.go
@@ -1,6 +1,6 @@
 // +build go1.9
 
-// Copyright 2018 Microsoft Corporation
+// Copyright 2019 Microsoft Corporation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/profiles/preview/dns/mgmt/dns/dnsapi/models.go
+++ b/profiles/preview/dns/mgmt/dns/dnsapi/models.go
@@ -1,6 +1,6 @@
 // +build go1.9
 
-// Copyright 2018 Microsoft Corporation
+// Copyright 2019 Microsoft Corporation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/profiles/preview/dns/mgmt/dns/models.go
+++ b/profiles/preview/dns/mgmt/dns/models.go
@@ -1,6 +1,6 @@
 // +build go1.9
 
-// Copyright 2018 Microsoft Corporation
+// Copyright 2019 Microsoft Corporation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/profiles/preview/domainservices/mgmt/aad/aadapi/models.go
+++ b/profiles/preview/domainservices/mgmt/aad/aadapi/models.go
@@ -1,6 +1,6 @@
 // +build go1.9
 
-// Copyright 2018 Microsoft Corporation
+// Copyright 2019 Microsoft Corporation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/profiles/preview/domainservices/mgmt/aad/models.go
+++ b/profiles/preview/domainservices/mgmt/aad/models.go
@@ -1,6 +1,6 @@
 // +build go1.9
 
-// Copyright 2018 Microsoft Corporation
+// Copyright 2019 Microsoft Corporation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/profiles/preview/eventgrid/eventgrid/eventgridapi/models.go
+++ b/profiles/preview/eventgrid/eventgrid/eventgridapi/models.go
@@ -1,6 +1,6 @@
 // +build go1.9
 
-// Copyright 2018 Microsoft Corporation
+// Copyright 2019 Microsoft Corporation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/profiles/preview/eventgrid/eventgrid/models.go
+++ b/profiles/preview/eventgrid/eventgrid/models.go
@@ -1,6 +1,6 @@
 // +build go1.9
 
-// Copyright 2018 Microsoft Corporation
+// Copyright 2019 Microsoft Corporation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/profiles/preview/eventgrid/mgmt/eventgrid/eventgridapi/models.go
+++ b/profiles/preview/eventgrid/mgmt/eventgrid/eventgridapi/models.go
@@ -1,6 +1,6 @@
 // +build go1.9
 
-// Copyright 2018 Microsoft Corporation
+// Copyright 2019 Microsoft Corporation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/profiles/preview/eventgrid/mgmt/eventgrid/models.go
+++ b/profiles/preview/eventgrid/mgmt/eventgrid/models.go
@@ -1,6 +1,6 @@
 // +build go1.9
 
-// Copyright 2018 Microsoft Corporation
+// Copyright 2019 Microsoft Corporation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/profiles/preview/eventhub/mgmt/eventhub/eventhubapi/models.go
+++ b/profiles/preview/eventhub/mgmt/eventhub/eventhubapi/models.go
@@ -1,6 +1,6 @@
 // +build go1.9
 
-// Copyright 2018 Microsoft Corporation
+// Copyright 2019 Microsoft Corporation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/profiles/preview/eventhub/mgmt/eventhub/models.go
+++ b/profiles/preview/eventhub/mgmt/eventhub/models.go
@@ -1,6 +1,6 @@
 // +build go1.9
 
-// Copyright 2018 Microsoft Corporation
+// Copyright 2019 Microsoft Corporation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/profiles/preview/graphrbac/graphrbac/graphrbacapi/models.go
+++ b/profiles/preview/graphrbac/graphrbac/graphrbacapi/models.go
@@ -1,6 +1,6 @@
 // +build go1.9
 
-// Copyright 2018 Microsoft Corporation
+// Copyright 2019 Microsoft Corporation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/profiles/preview/graphrbac/graphrbac/models.go
+++ b/profiles/preview/graphrbac/graphrbac/models.go
@@ -1,6 +1,6 @@
 // +build go1.9
 
-// Copyright 2018 Microsoft Corporation
+// Copyright 2019 Microsoft Corporation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/profiles/preview/iotcentral/mgmt/iotcentral/iotcentralapi/models.go
+++ b/profiles/preview/iotcentral/mgmt/iotcentral/iotcentralapi/models.go
@@ -1,6 +1,6 @@
 // +build go1.9
 
-// Copyright 2018 Microsoft Corporation
+// Copyright 2019 Microsoft Corporation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/profiles/preview/iotcentral/mgmt/iotcentral/models.go
+++ b/profiles/preview/iotcentral/mgmt/iotcentral/models.go
@@ -1,6 +1,6 @@
 // +build go1.9
 
-// Copyright 2018 Microsoft Corporation
+// Copyright 2019 Microsoft Corporation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/profiles/preview/iothub/mgmt/devices/devicesapi/models.go
+++ b/profiles/preview/iothub/mgmt/devices/devicesapi/models.go
@@ -1,6 +1,6 @@
 // +build go1.9
 
-// Copyright 2018 Microsoft Corporation
+// Copyright 2019 Microsoft Corporation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/profiles/preview/iothub/mgmt/devices/models.go
+++ b/profiles/preview/iothub/mgmt/devices/models.go
@@ -1,6 +1,6 @@
 // +build go1.9
 
-// Copyright 2018 Microsoft Corporation
+// Copyright 2019 Microsoft Corporation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/profiles/preview/keyvault/keyvault/keyvaultapi/models.go
+++ b/profiles/preview/keyvault/keyvault/keyvaultapi/models.go
@@ -1,6 +1,6 @@
 // +build go1.9
 
-// Copyright 2018 Microsoft Corporation
+// Copyright 2019 Microsoft Corporation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/profiles/preview/keyvault/keyvault/models.go
+++ b/profiles/preview/keyvault/keyvault/models.go
@@ -1,6 +1,6 @@
 // +build go1.9
 
-// Copyright 2018 Microsoft Corporation
+// Copyright 2019 Microsoft Corporation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/profiles/preview/keyvault/mgmt/keyvault/keyvaultapi/models.go
+++ b/profiles/preview/keyvault/mgmt/keyvault/keyvaultapi/models.go
@@ -1,6 +1,6 @@
 // +build go1.9
 
-// Copyright 2018 Microsoft Corporation
+// Copyright 2019 Microsoft Corporation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/profiles/preview/keyvault/mgmt/keyvault/models.go
+++ b/profiles/preview/keyvault/mgmt/keyvault/models.go
@@ -1,6 +1,6 @@
 // +build go1.9
 
-// Copyright 2018 Microsoft Corporation
+// Copyright 2019 Microsoft Corporation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/profiles/preview/labservices/mgmt/labservices/labservicesapi/models.go
+++ b/profiles/preview/labservices/mgmt/labservices/labservicesapi/models.go
@@ -1,6 +1,6 @@
 // +build go1.9
 
-// Copyright 2018 Microsoft Corporation
+// Copyright 2019 Microsoft Corporation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/profiles/preview/labservices/mgmt/labservices/models.go
+++ b/profiles/preview/labservices/mgmt/labservices/models.go
@@ -1,6 +1,6 @@
 // +build go1.9
 
-// Copyright 2018 Microsoft Corporation
+// Copyright 2019 Microsoft Corporation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/profiles/preview/logic/mgmt/logic/logicapi/models.go
+++ b/profiles/preview/logic/mgmt/logic/logicapi/models.go
@@ -1,6 +1,6 @@
 // +build go1.9
 
-// Copyright 2018 Microsoft Corporation
+// Copyright 2019 Microsoft Corporation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/profiles/preview/logic/mgmt/logic/models.go
+++ b/profiles/preview/logic/mgmt/logic/models.go
@@ -1,6 +1,6 @@
 // +build go1.9
 
-// Copyright 2018 Microsoft Corporation
+// Copyright 2019 Microsoft Corporation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/profiles/preview/machinelearning/mgmt/compute/models.go
+++ b/profiles/preview/machinelearning/mgmt/compute/models.go
@@ -1,6 +1,6 @@
 // +build go1.9
 
-// Copyright 2018 Microsoft Corporation
+// Copyright 2019 Microsoft Corporation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/profiles/preview/machinelearning/mgmt/webservices/models.go
+++ b/profiles/preview/machinelearning/mgmt/webservices/models.go
@@ -1,6 +1,6 @@
 // +build go1.9
 
-// Copyright 2018 Microsoft Corporation
+// Copyright 2019 Microsoft Corporation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/profiles/preview/machinelearning/mgmt/webservices/webservicesapi/models.go
+++ b/profiles/preview/machinelearning/mgmt/webservices/webservicesapi/models.go
@@ -1,6 +1,6 @@
 // +build go1.9
 
-// Copyright 2018 Microsoft Corporation
+// Copyright 2019 Microsoft Corporation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/profiles/preview/machinelearning/mgmt/workspaces/models.go
+++ b/profiles/preview/machinelearning/mgmt/workspaces/models.go
@@ -1,6 +1,6 @@
 // +build go1.9
 
-// Copyright 2018 Microsoft Corporation
+// Copyright 2019 Microsoft Corporation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/profiles/preview/machinelearning/mgmt/workspaces/workspacesapi/models.go
+++ b/profiles/preview/machinelearning/mgmt/workspaces/workspacesapi/models.go
@@ -1,6 +1,6 @@
 // +build go1.9
 
-// Copyright 2018 Microsoft Corporation
+// Copyright 2019 Microsoft Corporation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/profiles/preview/managementpartner/mgmt/managementpartner/models.go
+++ b/profiles/preview/managementpartner/mgmt/managementpartner/models.go
@@ -1,6 +1,6 @@
 // +build go1.9
 
-// Copyright 2018 Microsoft Corporation
+// Copyright 2019 Microsoft Corporation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/profiles/preview/maps/mgmt/maps/mapsapi/models.go
+++ b/profiles/preview/maps/mgmt/maps/mapsapi/models.go
@@ -1,6 +1,6 @@
 // +build go1.9
 
-// Copyright 2018 Microsoft Corporation
+// Copyright 2019 Microsoft Corporation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/profiles/preview/maps/mgmt/maps/models.go
+++ b/profiles/preview/maps/mgmt/maps/models.go
@@ -1,6 +1,6 @@
 // +build go1.9
 
-// Copyright 2018 Microsoft Corporation
+// Copyright 2019 Microsoft Corporation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/profiles/preview/marketplaceordering/mgmt/marketplaceordering/marketplaceorderingapi/models.go
+++ b/profiles/preview/marketplaceordering/mgmt/marketplaceordering/marketplaceorderingapi/models.go
@@ -1,6 +1,6 @@
 // +build go1.9
 
-// Copyright 2018 Microsoft Corporation
+// Copyright 2019 Microsoft Corporation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/profiles/preview/marketplaceordering/mgmt/marketplaceordering/models.go
+++ b/profiles/preview/marketplaceordering/mgmt/marketplaceordering/models.go
@@ -1,6 +1,6 @@
 // +build go1.9
 
-// Copyright 2018 Microsoft Corporation
+// Copyright 2019 Microsoft Corporation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/profiles/preview/mediaservices/mgmt/media/mediaapi/models.go
+++ b/profiles/preview/mediaservices/mgmt/media/mediaapi/models.go
@@ -1,6 +1,6 @@
 // +build go1.9
 
-// Copyright 2018 Microsoft Corporation
+// Copyright 2019 Microsoft Corporation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/profiles/preview/mediaservices/mgmt/media/models.go
+++ b/profiles/preview/mediaservices/mgmt/media/models.go
@@ -1,6 +1,6 @@
 // +build go1.9
 
-// Copyright 2018 Microsoft Corporation
+// Copyright 2019 Microsoft Corporation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/profiles/preview/migrate/mgmt/migrate/migrateapi/models.go
+++ b/profiles/preview/migrate/mgmt/migrate/migrateapi/models.go
@@ -1,6 +1,6 @@
 // +build go1.9
 
-// Copyright 2018 Microsoft Corporation
+// Copyright 2019 Microsoft Corporation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/profiles/preview/migrate/mgmt/migrate/models.go
+++ b/profiles/preview/migrate/mgmt/migrate/models.go
@@ -1,6 +1,6 @@
 // +build go1.9
 
-// Copyright 2018 Microsoft Corporation
+// Copyright 2019 Microsoft Corporation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/profiles/preview/mobileengagement/mgmt/mobileengagement/models.go
+++ b/profiles/preview/mobileengagement/mgmt/mobileengagement/models.go
@@ -1,6 +1,6 @@
 // +build go1.9
 
-// Copyright 2018 Microsoft Corporation
+// Copyright 2019 Microsoft Corporation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/profiles/preview/monitor/mgmt/insights/models.go
+++ b/profiles/preview/monitor/mgmt/insights/models.go
@@ -1,6 +1,6 @@
 // +build go1.9
 
-// Copyright 2018 Microsoft Corporation
+// Copyright 2019 Microsoft Corporation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/profiles/preview/msi/mgmt/msi/models.go
+++ b/profiles/preview/msi/mgmt/msi/models.go
@@ -1,6 +1,6 @@
 // +build go1.9
 
-// Copyright 2018 Microsoft Corporation
+// Copyright 2019 Microsoft Corporation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/profiles/preview/msi/mgmt/msi/msiapi/models.go
+++ b/profiles/preview/msi/mgmt/msi/msiapi/models.go
@@ -1,6 +1,6 @@
 // +build go1.9
 
-// Copyright 2018 Microsoft Corporation
+// Copyright 2019 Microsoft Corporation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/profiles/preview/mysql/mgmt/mysql/models.go
+++ b/profiles/preview/mysql/mgmt/mysql/models.go
@@ -1,6 +1,6 @@
 // +build go1.9
 
-// Copyright 2018 Microsoft Corporation
+// Copyright 2019 Microsoft Corporation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/profiles/preview/mysql/mgmt/mysql/mysqlapi/models.go
+++ b/profiles/preview/mysql/mgmt/mysql/mysqlapi/models.go
@@ -1,6 +1,6 @@
 // +build go1.9
 
-// Copyright 2018 Microsoft Corporation
+// Copyright 2019 Microsoft Corporation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/profiles/preview/network/mgmt/network/models.go
+++ b/profiles/preview/network/mgmt/network/models.go
@@ -1,6 +1,6 @@
 // +build go1.9
 
-// Copyright 2018 Microsoft Corporation
+// Copyright 2019 Microsoft Corporation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/profiles/preview/network/mgmt/network/networkapi/models.go
+++ b/profiles/preview/network/mgmt/network/networkapi/models.go
@@ -1,6 +1,6 @@
 // +build go1.9
 
-// Copyright 2018 Microsoft Corporation
+// Copyright 2019 Microsoft Corporation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/profiles/preview/notificationhubs/mgmt/notificationhubs/models.go
+++ b/profiles/preview/notificationhubs/mgmt/notificationhubs/models.go
@@ -1,6 +1,6 @@
 // +build go1.9
 
-// Copyright 2018 Microsoft Corporation
+// Copyright 2019 Microsoft Corporation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/profiles/preview/notificationhubs/mgmt/notificationhubs/notificationhubsapi/models.go
+++ b/profiles/preview/notificationhubs/mgmt/notificationhubs/notificationhubsapi/models.go
@@ -1,6 +1,6 @@
 // +build go1.9
 
-// Copyright 2018 Microsoft Corporation
+// Copyright 2019 Microsoft Corporation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/profiles/preview/operationalinsights/mgmt/operationalinsights/models.go
+++ b/profiles/preview/operationalinsights/mgmt/operationalinsights/models.go
@@ -1,6 +1,6 @@
 // +build go1.9
 
-// Copyright 2018 Microsoft Corporation
+// Copyright 2019 Microsoft Corporation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/profiles/preview/operationalinsights/mgmt/operationalinsights/operationalinsightsapi/models.go
+++ b/profiles/preview/operationalinsights/mgmt/operationalinsights/operationalinsightsapi/models.go
@@ -1,6 +1,6 @@
 // +build go1.9
 
-// Copyright 2018 Microsoft Corporation
+// Copyright 2019 Microsoft Corporation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/profiles/preview/operationalinsights/operationalinsights/models.go
+++ b/profiles/preview/operationalinsights/operationalinsights/models.go
@@ -1,6 +1,6 @@
 // +build go1.9
 
-// Copyright 2018 Microsoft Corporation
+// Copyright 2019 Microsoft Corporation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/profiles/preview/operationalinsights/operationalinsights/operationalinsightsapi/models.go
+++ b/profiles/preview/operationalinsights/operationalinsights/operationalinsightsapi/models.go
@@ -1,6 +1,6 @@
 // +build go1.9
 
-// Copyright 2018 Microsoft Corporation
+// Copyright 2019 Microsoft Corporation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/profiles/preview/policyinsights/mgmt/policyinsights/models.go
+++ b/profiles/preview/policyinsights/mgmt/policyinsights/models.go
@@ -1,6 +1,6 @@
 // +build go1.9
 
-// Copyright 2018 Microsoft Corporation
+// Copyright 2019 Microsoft Corporation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/profiles/preview/policyinsights/mgmt/policyinsights/policyinsightsapi/models.go
+++ b/profiles/preview/policyinsights/mgmt/policyinsights/policyinsightsapi/models.go
@@ -1,6 +1,6 @@
 // +build go1.9
 
-// Copyright 2018 Microsoft Corporation
+// Copyright 2019 Microsoft Corporation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/profiles/preview/postgresql/mgmt/postgresql/models.go
+++ b/profiles/preview/postgresql/mgmt/postgresql/models.go
@@ -1,6 +1,6 @@
 // +build go1.9
 
-// Copyright 2018 Microsoft Corporation
+// Copyright 2019 Microsoft Corporation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/profiles/preview/postgresql/mgmt/postgresql/postgresqlapi/models.go
+++ b/profiles/preview/postgresql/mgmt/postgresql/postgresqlapi/models.go
@@ -1,6 +1,6 @@
 // +build go1.9
 
-// Copyright 2018 Microsoft Corporation
+// Copyright 2019 Microsoft Corporation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/profiles/preview/powerbidedicated/mgmt/powerbidedicated/models.go
+++ b/profiles/preview/powerbidedicated/mgmt/powerbidedicated/models.go
@@ -1,6 +1,6 @@
 // +build go1.9
 
-// Copyright 2018 Microsoft Corporation
+// Copyright 2019 Microsoft Corporation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/profiles/preview/powerbidedicated/mgmt/powerbidedicated/powerbidedicatedapi/models.go
+++ b/profiles/preview/powerbidedicated/mgmt/powerbidedicated/powerbidedicatedapi/models.go
@@ -1,6 +1,6 @@
 // +build go1.9
 
-// Copyright 2018 Microsoft Corporation
+// Copyright 2019 Microsoft Corporation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/profiles/preview/powerbiembedded/mgmt/powerbiembedded/models.go
+++ b/profiles/preview/powerbiembedded/mgmt/powerbiembedded/models.go
@@ -1,6 +1,6 @@
 // +build go1.9
 
-// Copyright 2018 Microsoft Corporation
+// Copyright 2019 Microsoft Corporation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/profiles/preview/powerbiembedded/mgmt/powerbiembedded/powerbiembeddedapi/models.go
+++ b/profiles/preview/powerbiembedded/mgmt/powerbiembedded/powerbiembeddedapi/models.go
@@ -1,6 +1,6 @@
 // +build go1.9
 
-// Copyright 2018 Microsoft Corporation
+// Copyright 2019 Microsoft Corporation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/profiles/preview/preview/addons/mgmt/addons/addonsapi/models.go
+++ b/profiles/preview/preview/addons/mgmt/addons/addonsapi/models.go
@@ -1,6 +1,6 @@
 // +build go1.9
 
-// Copyright 2018 Microsoft Corporation
+// Copyright 2019 Microsoft Corporation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/profiles/preview/preview/addons/mgmt/addons/models.go
+++ b/profiles/preview/preview/addons/mgmt/addons/models.go
@@ -1,6 +1,6 @@
 // +build go1.9
 
-// Copyright 2018 Microsoft Corporation
+// Copyright 2019 Microsoft Corporation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/profiles/preview/preview/advisor/mgmt/advisor/advisorapi/models.go
+++ b/profiles/preview/preview/advisor/mgmt/advisor/advisorapi/models.go
@@ -1,6 +1,6 @@
 // +build go1.9
 
-// Copyright 2018 Microsoft Corporation
+// Copyright 2019 Microsoft Corporation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/profiles/preview/preview/advisor/mgmt/advisor/models.go
+++ b/profiles/preview/preview/advisor/mgmt/advisor/models.go
@@ -1,6 +1,6 @@
 // +build go1.9
 
-// Copyright 2018 Microsoft Corporation
+// Copyright 2019 Microsoft Corporation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/profiles/preview/preview/alertsmanagement/mgmt/alertsmanagement/models.go
+++ b/profiles/preview/preview/alertsmanagement/mgmt/alertsmanagement/models.go
@@ -1,6 +1,6 @@
 // +build go1.9
 
-// Copyright 2018 Microsoft Corporation
+// Copyright 2019 Microsoft Corporation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/profiles/preview/preview/apimanagement/ctrl/apimanagement/apimanagementapi/models.go
+++ b/profiles/preview/preview/apimanagement/ctrl/apimanagement/apimanagementapi/models.go
@@ -1,6 +1,6 @@
 // +build go1.9
 
-// Copyright 2018 Microsoft Corporation
+// Copyright 2019 Microsoft Corporation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/profiles/preview/preview/apimanagement/ctrl/apimanagement/models.go
+++ b/profiles/preview/preview/apimanagement/ctrl/apimanagement/models.go
@@ -1,6 +1,6 @@
 // +build go1.9
 
-// Copyright 2018 Microsoft Corporation
+// Copyright 2019 Microsoft Corporation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/profiles/preview/preview/apimanagement/mgmt/apimanagement/apimanagementapi/models.go
+++ b/profiles/preview/preview/apimanagement/mgmt/apimanagement/apimanagementapi/models.go
@@ -1,6 +1,6 @@
 // +build go1.9
 
-// Copyright 2018 Microsoft Corporation
+// Copyright 2019 Microsoft Corporation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/profiles/preview/preview/apimanagement/mgmt/apimanagement/models.go
+++ b/profiles/preview/preview/apimanagement/mgmt/apimanagement/models.go
@@ -1,6 +1,6 @@
 // +build go1.9
 
-// Copyright 2018 Microsoft Corporation
+// Copyright 2019 Microsoft Corporation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/profiles/preview/preview/appinsights/insights/insightsapi/models.go
+++ b/profiles/preview/preview/appinsights/insights/insightsapi/models.go
@@ -1,6 +1,6 @@
 // +build go1.9
 
-// Copyright 2018 Microsoft Corporation
+// Copyright 2019 Microsoft Corporation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/profiles/preview/preview/appinsights/insights/models.go
+++ b/profiles/preview/preview/appinsights/insights/models.go
@@ -1,6 +1,6 @@
 // +build go1.9
 
-// Copyright 2018 Microsoft Corporation
+// Copyright 2019 Microsoft Corporation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/profiles/preview/preview/authorization/mgmt/authorization/authorizationapi/models.go
+++ b/profiles/preview/preview/authorization/mgmt/authorization/authorizationapi/models.go
@@ -1,6 +1,6 @@
 // +build go1.9
 
-// Copyright 2018 Microsoft Corporation
+// Copyright 2019 Microsoft Corporation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/profiles/preview/preview/authorization/mgmt/authorization/models.go
+++ b/profiles/preview/preview/authorization/mgmt/authorization/models.go
@@ -1,6 +1,6 @@
 // +build go1.9
 
-// Copyright 2018 Microsoft Corporation
+// Copyright 2019 Microsoft Corporation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/profiles/preview/preview/automation/mgmt/automation/automationapi/models.go
+++ b/profiles/preview/preview/automation/mgmt/automation/automationapi/models.go
@@ -1,6 +1,6 @@
 // +build go1.9
 
-// Copyright 2018 Microsoft Corporation
+// Copyright 2019 Microsoft Corporation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/profiles/preview/preview/automation/mgmt/automation/models.go
+++ b/profiles/preview/preview/automation/mgmt/automation/models.go
@@ -1,6 +1,6 @@
 // +build go1.9
 
-// Copyright 2018 Microsoft Corporation
+// Copyright 2019 Microsoft Corporation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/profiles/preview/preview/automation/mgmt/automation/models.go
+++ b/profiles/preview/preview/automation/mgmt/automation/models.go
@@ -509,6 +509,7 @@ type NodeCountInformationClient = original.NodeCountInformationClient
 type NodeCountProperties = original.NodeCountProperties
 type NodeCounts = original.NodeCounts
 type NodeReportsClient = original.NodeReportsClient
+type NonAzureQueryProperties = original.NonAzureQueryProperties
 type ObjectDataTypesClient = original.ObjectDataTypesClient
 type Operation = original.Operation
 type OperationDisplay = original.OperationDisplay

--- a/profiles/preview/preview/batchai/mgmt/batchai/batchaiapi/models.go
+++ b/profiles/preview/preview/batchai/mgmt/batchai/batchaiapi/models.go
@@ -1,6 +1,6 @@
 // +build go1.9
 
-// Copyright 2018 Microsoft Corporation
+// Copyright 2019 Microsoft Corporation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/profiles/preview/preview/batchai/mgmt/batchai/models.go
+++ b/profiles/preview/preview/batchai/mgmt/batchai/models.go
@@ -1,6 +1,6 @@
 // +build go1.9
 
-// Copyright 2018 Microsoft Corporation
+// Copyright 2019 Microsoft Corporation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/profiles/preview/preview/billing/mgmt/billing/billingapi/models.go
+++ b/profiles/preview/preview/billing/mgmt/billing/billingapi/models.go
@@ -1,6 +1,6 @@
 // +build go1.9
 
-// Copyright 2018 Microsoft Corporation
+// Copyright 2019 Microsoft Corporation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/profiles/preview/preview/billing/mgmt/billing/models.go
+++ b/profiles/preview/preview/billing/mgmt/billing/models.go
@@ -1,6 +1,6 @@
 // +build go1.9
 
-// Copyright 2018 Microsoft Corporation
+// Copyright 2019 Microsoft Corporation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/profiles/preview/preview/blueprint/mgmt/blueprint/blueprintapi/models.go
+++ b/profiles/preview/preview/blueprint/mgmt/blueprint/blueprintapi/models.go
@@ -1,6 +1,6 @@
 // +build go1.9
 
-// Copyright 2018 Microsoft Corporation
+// Copyright 2019 Microsoft Corporation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/profiles/preview/preview/blueprint/mgmt/blueprint/models.go
+++ b/profiles/preview/preview/blueprint/mgmt/blueprint/models.go
@@ -1,6 +1,6 @@
 // +build go1.9
 
-// Copyright 2018 Microsoft Corporation
+// Copyright 2019 Microsoft Corporation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/profiles/preview/preview/botservice/mgmt/botservice/botserviceapi/models.go
+++ b/profiles/preview/preview/botservice/mgmt/botservice/botserviceapi/models.go
@@ -1,6 +1,6 @@
 // +build go1.9
 
-// Copyright 2018 Microsoft Corporation
+// Copyright 2019 Microsoft Corporation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/profiles/preview/preview/botservice/mgmt/botservice/models.go
+++ b/profiles/preview/preview/botservice/mgmt/botservice/models.go
@@ -1,6 +1,6 @@
 // +build go1.9
 
-// Copyright 2018 Microsoft Corporation
+// Copyright 2019 Microsoft Corporation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/profiles/preview/preview/cognitiveservices/mgmt/cognitiveservices/cognitiveservicesapi/models.go
+++ b/profiles/preview/preview/cognitiveservices/mgmt/cognitiveservices/cognitiveservicesapi/models.go
@@ -1,6 +1,6 @@
 // +build go1.9
 
-// Copyright 2018 Microsoft Corporation
+// Copyright 2019 Microsoft Corporation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/profiles/preview/preview/cognitiveservices/mgmt/cognitiveservices/models.go
+++ b/profiles/preview/preview/cognitiveservices/mgmt/cognitiveservices/models.go
@@ -1,6 +1,6 @@
 // +build go1.9
 
-// Copyright 2018 Microsoft Corporation
+// Copyright 2019 Microsoft Corporation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/profiles/preview/preview/cognitiveservices/visualsearch/models.go
+++ b/profiles/preview/preview/cognitiveservices/visualsearch/models.go
@@ -1,6 +1,6 @@
 // +build go1.9
 
-// Copyright 2018 Microsoft Corporation
+// Copyright 2019 Microsoft Corporation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/profiles/preview/preview/cognitiveservices/visualsearch/visualsearchapi/models.go
+++ b/profiles/preview/preview/cognitiveservices/visualsearch/visualsearchapi/models.go
@@ -1,6 +1,6 @@
 // +build go1.9
 
-// Copyright 2018 Microsoft Corporation
+// Copyright 2019 Microsoft Corporation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/profiles/preview/preview/commerce/mgmt/commerce/commerceapi/models.go
+++ b/profiles/preview/preview/commerce/mgmt/commerce/commerceapi/models.go
@@ -1,6 +1,6 @@
 // +build go1.9
 
-// Copyright 2018 Microsoft Corporation
+// Copyright 2019 Microsoft Corporation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/profiles/preview/preview/commerce/mgmt/commerce/models.go
+++ b/profiles/preview/preview/commerce/mgmt/commerce/models.go
@@ -1,6 +1,6 @@
 // +build go1.9
 
-// Copyright 2018 Microsoft Corporation
+// Copyright 2019 Microsoft Corporation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/profiles/preview/preview/compute/mgmt/compute/computeapi/models.go
+++ b/profiles/preview/preview/compute/mgmt/compute/computeapi/models.go
@@ -1,6 +1,6 @@
 // +build go1.9
 
-// Copyright 2018 Microsoft Corporation
+// Copyright 2019 Microsoft Corporation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/profiles/preview/preview/compute/mgmt/compute/models.go
+++ b/profiles/preview/preview/compute/mgmt/compute/models.go
@@ -1,6 +1,6 @@
 // +build go1.9
 
-// Copyright 2018 Microsoft Corporation
+// Copyright 2019 Microsoft Corporation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/profiles/preview/preview/consumption/mgmt/consumption/consumptionapi/models.go
+++ b/profiles/preview/preview/consumption/mgmt/consumption/consumptionapi/models.go
@@ -1,6 +1,6 @@
 // +build go1.9
 
-// Copyright 2018 Microsoft Corporation
+// Copyright 2019 Microsoft Corporation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/profiles/preview/preview/consumption/mgmt/consumption/models.go
+++ b/profiles/preview/preview/consumption/mgmt/consumption/models.go
@@ -1,6 +1,6 @@
 // +build go1.9
 
-// Copyright 2018 Microsoft Corporation
+// Copyright 2019 Microsoft Corporation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/profiles/preview/preview/containerinstance/mgmt/containerinstance/containerinstanceapi/models.go
+++ b/profiles/preview/preview/containerinstance/mgmt/containerinstance/containerinstanceapi/models.go
@@ -1,6 +1,6 @@
 // +build go1.9
 
-// Copyright 2018 Microsoft Corporation
+// Copyright 2019 Microsoft Corporation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/profiles/preview/preview/containerinstance/mgmt/containerinstance/models.go
+++ b/profiles/preview/preview/containerinstance/mgmt/containerinstance/models.go
@@ -1,6 +1,6 @@
 // +build go1.9
 
-// Copyright 2018 Microsoft Corporation
+// Copyright 2019 Microsoft Corporation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/profiles/preview/preview/containerregistry/mgmt/containerregistry/containerregistryapi/models.go
+++ b/profiles/preview/preview/containerregistry/mgmt/containerregistry/containerregistryapi/models.go
@@ -1,6 +1,6 @@
 // +build go1.9
 
-// Copyright 2018 Microsoft Corporation
+// Copyright 2019 Microsoft Corporation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/profiles/preview/preview/containerregistry/mgmt/containerregistry/models.go
+++ b/profiles/preview/preview/containerregistry/mgmt/containerregistry/models.go
@@ -1,6 +1,6 @@
 // +build go1.9
 
-// Copyright 2018 Microsoft Corporation
+// Copyright 2019 Microsoft Corporation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/profiles/preview/preview/containerservice/mgmt/containerservice/containerserviceapi/models.go
+++ b/profiles/preview/preview/containerservice/mgmt/containerservice/containerserviceapi/models.go
@@ -1,6 +1,6 @@
 // +build go1.9
 
-// Copyright 2018 Microsoft Corporation
+// Copyright 2019 Microsoft Corporation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/profiles/preview/preview/containerservice/mgmt/containerservice/models.go
+++ b/profiles/preview/preview/containerservice/mgmt/containerservice/models.go
@@ -1,6 +1,6 @@
 // +build go1.9
 
-// Copyright 2018 Microsoft Corporation
+// Copyright 2019 Microsoft Corporation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/profiles/preview/preview/costmanagement/mgmt/costmanagement/costmanagementapi/models.go
+++ b/profiles/preview/preview/costmanagement/mgmt/costmanagement/costmanagementapi/models.go
@@ -1,6 +1,6 @@
 // +build go1.9
 
-// Copyright 2018 Microsoft Corporation
+// Copyright 2019 Microsoft Corporation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/profiles/preview/preview/costmanagement/mgmt/costmanagement/models.go
+++ b/profiles/preview/preview/costmanagement/mgmt/costmanagement/models.go
@@ -1,6 +1,6 @@
 // +build go1.9
 
-// Copyright 2018 Microsoft Corporation
+// Copyright 2019 Microsoft Corporation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/profiles/preview/preview/datafactory/mgmt/datafactory/datafactoryapi/models.go
+++ b/profiles/preview/preview/datafactory/mgmt/datafactory/datafactoryapi/models.go
@@ -1,6 +1,6 @@
 // +build go1.9
 
-// Copyright 2018 Microsoft Corporation
+// Copyright 2019 Microsoft Corporation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/profiles/preview/preview/datafactory/mgmt/datafactory/models.go
+++ b/profiles/preview/preview/datafactory/mgmt/datafactory/models.go
@@ -1,6 +1,6 @@
 // +build go1.9
 
-// Copyright 2018 Microsoft Corporation
+// Copyright 2019 Microsoft Corporation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/profiles/preview/preview/datalake/analytics/catalog/catalogapi/models.go
+++ b/profiles/preview/preview/datalake/analytics/catalog/catalogapi/models.go
@@ -1,6 +1,6 @@
 // +build go1.9
 
-// Copyright 2018 Microsoft Corporation
+// Copyright 2019 Microsoft Corporation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/profiles/preview/preview/datalake/analytics/catalog/models.go
+++ b/profiles/preview/preview/datalake/analytics/catalog/models.go
@@ -1,6 +1,6 @@
 // +build go1.9
 
-// Copyright 2018 Microsoft Corporation
+// Copyright 2019 Microsoft Corporation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/profiles/preview/preview/datalake/analytics/job/jobapi/models.go
+++ b/profiles/preview/preview/datalake/analytics/job/jobapi/models.go
@@ -1,6 +1,6 @@
 // +build go1.9
 
-// Copyright 2018 Microsoft Corporation
+// Copyright 2019 Microsoft Corporation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/profiles/preview/preview/datalake/analytics/job/models.go
+++ b/profiles/preview/preview/datalake/analytics/job/models.go
@@ -1,6 +1,6 @@
 // +build go1.9
 
-// Copyright 2018 Microsoft Corporation
+// Copyright 2019 Microsoft Corporation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/profiles/preview/preview/datalake/analytics/mgmt/account/accountapi/models.go
+++ b/profiles/preview/preview/datalake/analytics/mgmt/account/accountapi/models.go
@@ -1,6 +1,6 @@
 // +build go1.9
 
-// Copyright 2018 Microsoft Corporation
+// Copyright 2019 Microsoft Corporation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/profiles/preview/preview/datalake/analytics/mgmt/account/models.go
+++ b/profiles/preview/preview/datalake/analytics/mgmt/account/models.go
@@ -1,6 +1,6 @@
 // +build go1.9
 
-// Copyright 2018 Microsoft Corporation
+// Copyright 2019 Microsoft Corporation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/profiles/preview/preview/datalake/store/filesystem/filesystemapi/models.go
+++ b/profiles/preview/preview/datalake/store/filesystem/filesystemapi/models.go
@@ -1,6 +1,6 @@
 // +build go1.9
 
-// Copyright 2018 Microsoft Corporation
+// Copyright 2019 Microsoft Corporation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/profiles/preview/preview/datalake/store/filesystem/models.go
+++ b/profiles/preview/preview/datalake/store/filesystem/models.go
@@ -1,6 +1,6 @@
 // +build go1.9
 
-// Copyright 2018 Microsoft Corporation
+// Copyright 2019 Microsoft Corporation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/profiles/preview/preview/datalake/store/mgmt/account/accountapi/models.go
+++ b/profiles/preview/preview/datalake/store/mgmt/account/accountapi/models.go
@@ -1,6 +1,6 @@
 // +build go1.9
 
-// Copyright 2018 Microsoft Corporation
+// Copyright 2019 Microsoft Corporation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/profiles/preview/preview/datalake/store/mgmt/account/models.go
+++ b/profiles/preview/preview/datalake/store/mgmt/account/models.go
@@ -1,6 +1,6 @@
 // +build go1.9
 
-// Copyright 2018 Microsoft Corporation
+// Copyright 2019 Microsoft Corporation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/profiles/preview/preview/datamigration/mgmt/datamigration/datamigrationapi/models.go
+++ b/profiles/preview/preview/datamigration/mgmt/datamigration/datamigrationapi/models.go
@@ -1,6 +1,6 @@
 // +build go1.9
 
-// Copyright 2018 Microsoft Corporation
+// Copyright 2019 Microsoft Corporation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/profiles/preview/preview/datamigration/mgmt/datamigration/models.go
+++ b/profiles/preview/preview/datamigration/mgmt/datamigration/models.go
@@ -1,6 +1,6 @@
 // +build go1.9
 
-// Copyright 2018 Microsoft Corporation
+// Copyright 2019 Microsoft Corporation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/profiles/preview/preview/deploymentmanager/mgmt/deploymentmanager/deploymentmanagerapi/models.go
+++ b/profiles/preview/preview/deploymentmanager/mgmt/deploymentmanager/deploymentmanagerapi/models.go
@@ -1,6 +1,6 @@
 // +build go1.9
 
-// Copyright 2018 Microsoft Corporation
+// Copyright 2019 Microsoft Corporation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/profiles/preview/preview/deploymentmanager/mgmt/deploymentmanager/models.go
+++ b/profiles/preview/preview/deploymentmanager/mgmt/deploymentmanager/models.go
@@ -1,6 +1,6 @@
 // +build go1.9
 
-// Copyright 2018 Microsoft Corporation
+// Copyright 2019 Microsoft Corporation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/profiles/preview/preview/devspaces/mgmt/devspaces/devspacesapi/models.go
+++ b/profiles/preview/preview/devspaces/mgmt/devspaces/devspacesapi/models.go
@@ -1,6 +1,6 @@
 // +build go1.9
 
-// Copyright 2018 Microsoft Corporation
+// Copyright 2019 Microsoft Corporation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/profiles/preview/preview/devspaces/mgmt/devspaces/models.go
+++ b/profiles/preview/preview/devspaces/mgmt/devspaces/models.go
@@ -1,6 +1,6 @@
 // +build go1.9
 
-// Copyright 2018 Microsoft Corporation
+// Copyright 2019 Microsoft Corporation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/profiles/preview/preview/devtestlabs/mgmt/dtl/dtlapi/models.go
+++ b/profiles/preview/preview/devtestlabs/mgmt/dtl/dtlapi/models.go
@@ -1,6 +1,6 @@
 // +build go1.9
 
-// Copyright 2018 Microsoft Corporation
+// Copyright 2019 Microsoft Corporation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/profiles/preview/preview/devtestlabs/mgmt/dtl/models.go
+++ b/profiles/preview/preview/devtestlabs/mgmt/dtl/models.go
@@ -1,6 +1,6 @@
 // +build go1.9
 
-// Copyright 2018 Microsoft Corporation
+// Copyright 2019 Microsoft Corporation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/profiles/preview/preview/dns/mgmt/dns/dnsapi/models.go
+++ b/profiles/preview/preview/dns/mgmt/dns/dnsapi/models.go
@@ -1,6 +1,6 @@
 // +build go1.9
 
-// Copyright 2018 Microsoft Corporation
+// Copyright 2019 Microsoft Corporation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/profiles/preview/preview/dns/mgmt/dns/models.go
+++ b/profiles/preview/preview/dns/mgmt/dns/models.go
@@ -1,6 +1,6 @@
 // +build go1.9
 
-// Copyright 2018 Microsoft Corporation
+// Copyright 2019 Microsoft Corporation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/profiles/preview/preview/engagementfabric/mgmt/engagementfabric/engagementfabricapi/models.go
+++ b/profiles/preview/preview/engagementfabric/mgmt/engagementfabric/engagementfabricapi/models.go
@@ -1,6 +1,6 @@
 // +build go1.9
 
-// Copyright 2018 Microsoft Corporation
+// Copyright 2019 Microsoft Corporation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/profiles/preview/preview/engagementfabric/mgmt/engagementfabric/models.go
+++ b/profiles/preview/preview/engagementfabric/mgmt/engagementfabric/models.go
@@ -1,6 +1,6 @@
 // +build go1.9
 
-// Copyright 2018 Microsoft Corporation
+// Copyright 2019 Microsoft Corporation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/profiles/preview/preview/eventgrid/mgmt/eventgrid/eventgridapi/models.go
+++ b/profiles/preview/preview/eventgrid/mgmt/eventgrid/eventgridapi/models.go
@@ -1,6 +1,6 @@
 // +build go1.9
 
-// Copyright 2018 Microsoft Corporation
+// Copyright 2019 Microsoft Corporation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/profiles/preview/preview/eventgrid/mgmt/eventgrid/models.go
+++ b/profiles/preview/preview/eventgrid/mgmt/eventgrid/models.go
@@ -1,6 +1,6 @@
 // +build go1.9
 
-// Copyright 2018 Microsoft Corporation
+// Copyright 2019 Microsoft Corporation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/profiles/preview/preview/eventhub/mgmt/eventhub/eventhubapi/models.go
+++ b/profiles/preview/preview/eventhub/mgmt/eventhub/eventhubapi/models.go
@@ -1,6 +1,6 @@
 // +build go1.9
 
-// Copyright 2018 Microsoft Corporation
+// Copyright 2019 Microsoft Corporation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/profiles/preview/preview/eventhub/mgmt/eventhub/models.go
+++ b/profiles/preview/preview/eventhub/mgmt/eventhub/models.go
@@ -1,6 +1,6 @@
 // +build go1.9
 
-// Copyright 2018 Microsoft Corporation
+// Copyright 2019 Microsoft Corporation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/profiles/preview/preview/frontdoor/mgmt/frontdoor/frontdoorapi/models.go
+++ b/profiles/preview/preview/frontdoor/mgmt/frontdoor/frontdoorapi/models.go
@@ -1,6 +1,6 @@
 // +build go1.9
 
-// Copyright 2018 Microsoft Corporation
+// Copyright 2019 Microsoft Corporation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/profiles/preview/preview/frontdoor/mgmt/frontdoor/models.go
+++ b/profiles/preview/preview/frontdoor/mgmt/frontdoor/models.go
@@ -1,6 +1,6 @@
 // +build go1.9
 
-// Copyright 2018 Microsoft Corporation
+// Copyright 2019 Microsoft Corporation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/profiles/preview/preview/hanaonazure/mgmt/hanaonazure/hanaonazureapi/models.go
+++ b/profiles/preview/preview/hanaonazure/mgmt/hanaonazure/hanaonazureapi/models.go
@@ -1,6 +1,6 @@
 // +build go1.9
 
-// Copyright 2018 Microsoft Corporation
+// Copyright 2019 Microsoft Corporation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/profiles/preview/preview/hanaonazure/mgmt/hanaonazure/models.go
+++ b/profiles/preview/preview/hanaonazure/mgmt/hanaonazure/models.go
@@ -1,6 +1,6 @@
 // +build go1.9
 
-// Copyright 2018 Microsoft Corporation
+// Copyright 2019 Microsoft Corporation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/profiles/preview/preview/hanaonazure/mgmt/hanaonazure/models.go
+++ b/profiles/preview/preview/hanaonazure/mgmt/hanaonazure/models.go
@@ -89,6 +89,7 @@ type OperationList = original.OperationList
 type OperationsClient = original.OperationsClient
 type Resource = original.Resource
 type StorageProfile = original.StorageProfile
+type Tags = original.Tags
 
 func New(subscriptionID string) BaseClient {
 	return original.New(subscriptionID)

--- a/profiles/preview/preview/hdinsight/hdinsight/hdinsightapi/models.go
+++ b/profiles/preview/preview/hdinsight/hdinsight/hdinsightapi/models.go
@@ -1,6 +1,6 @@
 // +build go1.9
 
-// Copyright 2018 Microsoft Corporation
+// Copyright 2019 Microsoft Corporation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/profiles/preview/preview/hdinsight/hdinsight/models.go
+++ b/profiles/preview/preview/hdinsight/hdinsight/models.go
@@ -1,6 +1,6 @@
 // +build go1.9
 
-// Copyright 2018 Microsoft Corporation
+// Copyright 2019 Microsoft Corporation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/profiles/preview/preview/hdinsight/mgmt/hdinsight/hdinsightapi/models.go
+++ b/profiles/preview/preview/hdinsight/mgmt/hdinsight/hdinsightapi/models.go
@@ -1,6 +1,6 @@
 // +build go1.9
 
-// Copyright 2018 Microsoft Corporation
+// Copyright 2019 Microsoft Corporation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/profiles/preview/preview/hdinsight/mgmt/hdinsight/models.go
+++ b/profiles/preview/preview/hdinsight/mgmt/hdinsight/models.go
@@ -1,6 +1,6 @@
 // +build go1.9
 
-// Copyright 2018 Microsoft Corporation
+// Copyright 2019 Microsoft Corporation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/profiles/preview/preview/iotspaces/mgmt/iotspaces/iotspacesapi/models.go
+++ b/profiles/preview/preview/iotspaces/mgmt/iotspaces/iotspacesapi/models.go
@@ -1,6 +1,6 @@
 // +build go1.9
 
-// Copyright 2018 Microsoft Corporation
+// Copyright 2019 Microsoft Corporation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/profiles/preview/preview/iotspaces/mgmt/iotspaces/models.go
+++ b/profiles/preview/preview/iotspaces/mgmt/iotspaces/models.go
@@ -1,6 +1,6 @@
 // +build go1.9
 
-// Copyright 2018 Microsoft Corporation
+// Copyright 2019 Microsoft Corporation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/profiles/preview/preview/kusto/mgmt/kusto/kustoapi/models.go
+++ b/profiles/preview/preview/kusto/mgmt/kusto/kustoapi/models.go
@@ -1,6 +1,6 @@
 // +build go1.9
 
-// Copyright 2018 Microsoft Corporation
+// Copyright 2019 Microsoft Corporation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/profiles/preview/preview/kusto/mgmt/kusto/models.go
+++ b/profiles/preview/preview/kusto/mgmt/kusto/models.go
@@ -1,6 +1,6 @@
 // +build go1.9
 
-// Copyright 2018 Microsoft Corporation
+// Copyright 2019 Microsoft Corporation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/profiles/preview/preview/logic/mgmt/logic/logicapi/models.go
+++ b/profiles/preview/preview/logic/mgmt/logic/logicapi/models.go
@@ -1,6 +1,6 @@
 // +build go1.9
 
-// Copyright 2018 Microsoft Corporation
+// Copyright 2019 Microsoft Corporation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/profiles/preview/preview/logic/mgmt/logic/models.go
+++ b/profiles/preview/preview/logic/mgmt/logic/models.go
@@ -1,6 +1,6 @@
 // +build go1.9
 
-// Copyright 2018 Microsoft Corporation
+// Copyright 2019 Microsoft Corporation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/profiles/preview/preview/machinelearning/mgmt/commitmentplans/commitmentplansapi/models.go
+++ b/profiles/preview/preview/machinelearning/mgmt/commitmentplans/commitmentplansapi/models.go
@@ -1,6 +1,6 @@
 // +build go1.9
 
-// Copyright 2018 Microsoft Corporation
+// Copyright 2019 Microsoft Corporation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/profiles/preview/preview/machinelearning/mgmt/commitmentplans/models.go
+++ b/profiles/preview/preview/machinelearning/mgmt/commitmentplans/models.go
@@ -1,6 +1,6 @@
 // +build go1.9
 
-// Copyright 2018 Microsoft Corporation
+// Copyright 2019 Microsoft Corporation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/profiles/preview/preview/machinelearning/mgmt/compute/computeapi/models.go
+++ b/profiles/preview/preview/machinelearning/mgmt/compute/computeapi/models.go
@@ -1,6 +1,6 @@
 // +build go1.9
 
-// Copyright 2018 Microsoft Corporation
+// Copyright 2019 Microsoft Corporation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/profiles/preview/preview/machinelearning/mgmt/compute/models.go
+++ b/profiles/preview/preview/machinelearning/mgmt/compute/models.go
@@ -1,6 +1,6 @@
 // +build go1.9
 
-// Copyright 2018 Microsoft Corporation
+// Copyright 2019 Microsoft Corporation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/profiles/preview/preview/machinelearning/mgmt/experimentation/experimentationapi/models.go
+++ b/profiles/preview/preview/machinelearning/mgmt/experimentation/experimentationapi/models.go
@@ -1,6 +1,6 @@
 // +build go1.9
 
-// Copyright 2018 Microsoft Corporation
+// Copyright 2019 Microsoft Corporation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/profiles/preview/preview/machinelearning/mgmt/experimentation/models.go
+++ b/profiles/preview/preview/machinelearning/mgmt/experimentation/models.go
@@ -1,6 +1,6 @@
 // +build go1.9
 
-// Copyright 2018 Microsoft Corporation
+// Copyright 2019 Microsoft Corporation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/profiles/preview/preview/machinelearning/mgmt/services/models.go
+++ b/profiles/preview/preview/machinelearning/mgmt/services/models.go
@@ -1,6 +1,6 @@
 // +build go1.9
 
-// Copyright 2018 Microsoft Corporation
+// Copyright 2019 Microsoft Corporation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/profiles/preview/preview/machinelearning/mgmt/services/servicesapi/models.go
+++ b/profiles/preview/preview/machinelearning/mgmt/services/servicesapi/models.go
@@ -1,6 +1,6 @@
 // +build go1.9
 
-// Copyright 2018 Microsoft Corporation
+// Copyright 2019 Microsoft Corporation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/profiles/preview/preview/machinelearning/mgmt/webservices/models.go
+++ b/profiles/preview/preview/machinelearning/mgmt/webservices/models.go
@@ -1,6 +1,6 @@
 // +build go1.9
 
-// Copyright 2018 Microsoft Corporation
+// Copyright 2019 Microsoft Corporation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/profiles/preview/preview/machinelearning/mgmt/webservices/webservicesapi/models.go
+++ b/profiles/preview/preview/machinelearning/mgmt/webservices/webservicesapi/models.go
@@ -1,6 +1,6 @@
 // +build go1.9
 
-// Copyright 2018 Microsoft Corporation
+// Copyright 2019 Microsoft Corporation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/profiles/preview/preview/managementpartner/mgmt/managementpartner/managementpartnerapi/models.go
+++ b/profiles/preview/preview/managementpartner/mgmt/managementpartner/managementpartnerapi/models.go
@@ -1,6 +1,6 @@
 // +build go1.9
 
-// Copyright 2018 Microsoft Corporation
+// Copyright 2019 Microsoft Corporation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/profiles/preview/preview/managementpartner/mgmt/managementpartner/models.go
+++ b/profiles/preview/preview/managementpartner/mgmt/managementpartner/models.go
@@ -1,6 +1,6 @@
 // +build go1.9
 
-// Copyright 2018 Microsoft Corporation
+// Copyright 2019 Microsoft Corporation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/profiles/preview/preview/mariadb/mgmt/mariadb/mariadbapi/models.go
+++ b/profiles/preview/preview/mariadb/mgmt/mariadb/mariadbapi/models.go
@@ -1,6 +1,6 @@
 // +build go1.9
 
-// Copyright 2018 Microsoft Corporation
+// Copyright 2019 Microsoft Corporation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/profiles/preview/preview/mariadb/mgmt/mariadb/models.go
+++ b/profiles/preview/preview/mariadb/mgmt/mariadb/models.go
@@ -1,6 +1,6 @@
 // +build go1.9
 
-// Copyright 2018 Microsoft Corporation
+// Copyright 2019 Microsoft Corporation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/profiles/preview/preview/mediaservices/mgmt/media/mediaapi/models.go
+++ b/profiles/preview/preview/mediaservices/mgmt/media/mediaapi/models.go
@@ -1,6 +1,6 @@
 // +build go1.9
 
-// Copyright 2018 Microsoft Corporation
+// Copyright 2019 Microsoft Corporation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/profiles/preview/preview/mediaservices/mgmt/media/models.go
+++ b/profiles/preview/preview/mediaservices/mgmt/media/models.go
@@ -1,6 +1,6 @@
 // +build go1.9
 
-// Copyright 2018 Microsoft Corporation
+// Copyright 2019 Microsoft Corporation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/profiles/preview/preview/monitor/mgmt/insights/insightsapi/models.go
+++ b/profiles/preview/preview/monitor/mgmt/insights/insightsapi/models.go
@@ -1,6 +1,6 @@
 // +build go1.9
 
-// Copyright 2018 Microsoft Corporation
+// Copyright 2019 Microsoft Corporation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/profiles/preview/preview/monitor/mgmt/insights/models.go
+++ b/profiles/preview/preview/monitor/mgmt/insights/models.go
@@ -1,6 +1,6 @@
 // +build go1.9
 
-// Copyright 2018 Microsoft Corporation
+// Copyright 2019 Microsoft Corporation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/profiles/preview/preview/monitor/monitor/models.go
+++ b/profiles/preview/preview/monitor/monitor/models.go
@@ -1,6 +1,6 @@
 // +build go1.9
 
-// Copyright 2018 Microsoft Corporation
+// Copyright 2019 Microsoft Corporation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/profiles/preview/preview/monitor/monitor/monitorapi/models.go
+++ b/profiles/preview/preview/monitor/monitor/monitorapi/models.go
@@ -1,6 +1,6 @@
 // +build go1.9
 
-// Copyright 2018 Microsoft Corporation
+// Copyright 2019 Microsoft Corporation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/profiles/preview/preview/msi/mgmt/msi/models.go
+++ b/profiles/preview/preview/msi/mgmt/msi/models.go
@@ -1,6 +1,6 @@
 // +build go1.9
 
-// Copyright 2018 Microsoft Corporation
+// Copyright 2019 Microsoft Corporation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/profiles/preview/preview/msi/mgmt/msi/msiapi/models.go
+++ b/profiles/preview/preview/msi/mgmt/msi/msiapi/models.go
@@ -1,6 +1,6 @@
 // +build go1.9
 
-// Copyright 2018 Microsoft Corporation
+// Copyright 2019 Microsoft Corporation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/profiles/preview/preview/network/mgmt/network/models.go
+++ b/profiles/preview/preview/network/mgmt/network/models.go
@@ -1,6 +1,6 @@
 // +build go1.9
 
-// Copyright 2018 Microsoft Corporation
+// Copyright 2019 Microsoft Corporation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/profiles/preview/preview/network/mgmt/network/networkapi/models.go
+++ b/profiles/preview/preview/network/mgmt/network/networkapi/models.go
@@ -1,6 +1,6 @@
 // +build go1.9
 
-// Copyright 2018 Microsoft Corporation
+// Copyright 2019 Microsoft Corporation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/profiles/preview/preview/operationalinsights/mgmt/operationalinsights/models.go
+++ b/profiles/preview/preview/operationalinsights/mgmt/operationalinsights/models.go
@@ -1,6 +1,6 @@
 // +build go1.9
 
-// Copyright 2018 Microsoft Corporation
+// Copyright 2019 Microsoft Corporation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/profiles/preview/preview/operationalinsights/mgmt/operationalinsights/operationalinsightsapi/models.go
+++ b/profiles/preview/preview/operationalinsights/mgmt/operationalinsights/operationalinsightsapi/models.go
@@ -1,6 +1,6 @@
 // +build go1.9
 
-// Copyright 2018 Microsoft Corporation
+// Copyright 2019 Microsoft Corporation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/profiles/preview/preview/operationalinsights/mgmt/servicemap/models.go
+++ b/profiles/preview/preview/operationalinsights/mgmt/servicemap/models.go
@@ -1,6 +1,6 @@
 // +build go1.9
 
-// Copyright 2018 Microsoft Corporation
+// Copyright 2019 Microsoft Corporation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/profiles/preview/preview/operationalinsights/mgmt/servicemap/servicemapapi/models.go
+++ b/profiles/preview/preview/operationalinsights/mgmt/servicemap/servicemapapi/models.go
@@ -1,6 +1,6 @@
 // +build go1.9
 
-// Copyright 2018 Microsoft Corporation
+// Copyright 2019 Microsoft Corporation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/profiles/preview/preview/operationsmanagement/mgmt/operationsmanagement/models.go
+++ b/profiles/preview/preview/operationsmanagement/mgmt/operationsmanagement/models.go
@@ -1,6 +1,6 @@
 // +build go1.9
 
-// Copyright 2018 Microsoft Corporation
+// Copyright 2019 Microsoft Corporation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/profiles/preview/preview/operationsmanagement/mgmt/operationsmanagement/operationsmanagementapi/models.go
+++ b/profiles/preview/preview/operationsmanagement/mgmt/operationsmanagement/operationsmanagementapi/models.go
@@ -1,6 +1,6 @@
 // +build go1.9
 
-// Copyright 2018 Microsoft Corporation
+// Copyright 2019 Microsoft Corporation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/profiles/preview/preview/policyinsights/mgmt/policyinsights/models.go
+++ b/profiles/preview/preview/policyinsights/mgmt/policyinsights/models.go
@@ -1,6 +1,6 @@
 // +build go1.9
 
-// Copyright 2018 Microsoft Corporation
+// Copyright 2019 Microsoft Corporation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/profiles/preview/preview/policyinsights/mgmt/policyinsights/policyinsightsapi/models.go
+++ b/profiles/preview/preview/policyinsights/mgmt/policyinsights/policyinsightsapi/models.go
@@ -1,6 +1,6 @@
 // +build go1.9
 
-// Copyright 2018 Microsoft Corporation
+// Copyright 2019 Microsoft Corporation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/profiles/preview/preview/provisioningservices/mgmt/iothub/iothubapi/models.go
+++ b/profiles/preview/preview/provisioningservices/mgmt/iothub/iothubapi/models.go
@@ -1,6 +1,6 @@
 // +build go1.9
 
-// Copyright 2018 Microsoft Corporation
+// Copyright 2019 Microsoft Corporation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/profiles/preview/preview/provisioningservices/mgmt/iothub/models.go
+++ b/profiles/preview/preview/provisioningservices/mgmt/iothub/models.go
@@ -1,6 +1,6 @@
 // +build go1.9
 
-// Copyright 2018 Microsoft Corporation
+// Copyright 2019 Microsoft Corporation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/profiles/preview/preview/reservations/mgmt/reservations/models.go
+++ b/profiles/preview/preview/reservations/mgmt/reservations/models.go
@@ -1,6 +1,6 @@
 // +build go1.9
 
-// Copyright 2018 Microsoft Corporation
+// Copyright 2019 Microsoft Corporation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/profiles/preview/preview/reservations/mgmt/reservations/reservationsapi/models.go
+++ b/profiles/preview/preview/reservations/mgmt/reservations/reservationsapi/models.go
@@ -1,6 +1,6 @@
 // +build go1.9
 
-// Copyright 2018 Microsoft Corporation
+// Copyright 2019 Microsoft Corporation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/profiles/preview/preview/resources/mgmt/managedapplications/managedapplicationsapi/models.go
+++ b/profiles/preview/preview/resources/mgmt/managedapplications/managedapplicationsapi/models.go
@@ -1,6 +1,6 @@
 // +build go1.9
 
-// Copyright 2018 Microsoft Corporation
+// Copyright 2019 Microsoft Corporation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/profiles/preview/preview/resources/mgmt/managedapplications/models.go
+++ b/profiles/preview/preview/resources/mgmt/managedapplications/models.go
@@ -1,6 +1,6 @@
 // +build go1.9
 
-// Copyright 2018 Microsoft Corporation
+// Copyright 2019 Microsoft Corporation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/profiles/preview/preview/resources/mgmt/managementgroups/managementgroupsapi/models.go
+++ b/profiles/preview/preview/resources/mgmt/managementgroups/managementgroupsapi/models.go
@@ -1,6 +1,6 @@
 // +build go1.9
 
-// Copyright 2018 Microsoft Corporation
+// Copyright 2019 Microsoft Corporation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/profiles/preview/preview/resources/mgmt/managementgroups/models.go
+++ b/profiles/preview/preview/resources/mgmt/managementgroups/models.go
@@ -1,6 +1,6 @@
 // +build go1.9
 
-// Copyright 2018 Microsoft Corporation
+// Copyright 2019 Microsoft Corporation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/profiles/preview/preview/resources/mgmt/policy/models.go
+++ b/profiles/preview/preview/resources/mgmt/policy/models.go
@@ -1,6 +1,6 @@
 // +build go1.9
 
-// Copyright 2018 Microsoft Corporation
+// Copyright 2019 Microsoft Corporation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/profiles/preview/preview/resources/mgmt/policy/policyapi/models.go
+++ b/profiles/preview/preview/resources/mgmt/policy/policyapi/models.go
@@ -1,6 +1,6 @@
 // +build go1.9
 
-// Copyright 2018 Microsoft Corporation
+// Copyright 2019 Microsoft Corporation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/profiles/preview/preview/scheduler/mgmt/scheduler/models.go
+++ b/profiles/preview/preview/scheduler/mgmt/scheduler/models.go
@@ -1,6 +1,6 @@
 // +build go1.9
 
-// Copyright 2018 Microsoft Corporation
+// Copyright 2019 Microsoft Corporation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/profiles/preview/preview/scheduler/mgmt/scheduler/schedulerapi/models.go
+++ b/profiles/preview/preview/scheduler/mgmt/scheduler/schedulerapi/models.go
@@ -1,6 +1,6 @@
 // +build go1.9
 
-// Copyright 2018 Microsoft Corporation
+// Copyright 2019 Microsoft Corporation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/profiles/preview/preview/security/mgmt/security/models.go
+++ b/profiles/preview/preview/security/mgmt/security/models.go
@@ -1,6 +1,6 @@
 // +build go1.9
 
-// Copyright 2018 Microsoft Corporation
+// Copyright 2019 Microsoft Corporation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/profiles/preview/preview/security/mgmt/security/securityapi/models.go
+++ b/profiles/preview/preview/security/mgmt/security/securityapi/models.go
@@ -1,6 +1,6 @@
 // +build go1.9
 
-// Copyright 2018 Microsoft Corporation
+// Copyright 2019 Microsoft Corporation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/profiles/preview/preview/servicefabric/mgmt/servicefabric/models.go
+++ b/profiles/preview/preview/servicefabric/mgmt/servicefabric/models.go
@@ -1,6 +1,6 @@
 // +build go1.9
 
-// Copyright 2018 Microsoft Corporation
+// Copyright 2019 Microsoft Corporation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/profiles/preview/preview/servicefabricmesh/mgmt/servicefabricmesh/models.go
+++ b/profiles/preview/preview/servicefabricmesh/mgmt/servicefabricmesh/models.go
@@ -1,6 +1,6 @@
 // +build go1.9
 
-// Copyright 2018 Microsoft Corporation
+// Copyright 2019 Microsoft Corporation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/profiles/preview/preview/servicefabricmesh/mgmt/servicefabricmesh/servicefabricmeshapi/models.go
+++ b/profiles/preview/preview/servicefabricmesh/mgmt/servicefabricmesh/servicefabricmeshapi/models.go
@@ -1,6 +1,6 @@
 // +build go1.9
 
-// Copyright 2018 Microsoft Corporation
+// Copyright 2019 Microsoft Corporation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/profiles/preview/preview/signalr/mgmt/signalr/models.go
+++ b/profiles/preview/preview/signalr/mgmt/signalr/models.go
@@ -1,6 +1,6 @@
 // +build go1.9
 
-// Copyright 2018 Microsoft Corporation
+// Copyright 2019 Microsoft Corporation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/profiles/preview/preview/signalr/mgmt/signalr/signalrapi/models.go
+++ b/profiles/preview/preview/signalr/mgmt/signalr/signalrapi/models.go
@@ -1,6 +1,6 @@
 // +build go1.9
 
-// Copyright 2018 Microsoft Corporation
+// Copyright 2019 Microsoft Corporation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/profiles/preview/preview/sql/mgmt/sql/models.go
+++ b/profiles/preview/preview/sql/mgmt/sql/models.go
@@ -1,6 +1,6 @@
 // +build go1.9
 
-// Copyright 2018 Microsoft Corporation
+// Copyright 2019 Microsoft Corporation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/profiles/preview/preview/sql/mgmt/sql/sqlapi/models.go
+++ b/profiles/preview/preview/sql/mgmt/sql/sqlapi/models.go
@@ -1,6 +1,6 @@
 // +build go1.9
 
-// Copyright 2018 Microsoft Corporation
+// Copyright 2019 Microsoft Corporation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/profiles/preview/preview/sqlvirtualmachine/mgmt/sqlvirtualmachine/models.go
+++ b/profiles/preview/preview/sqlvirtualmachine/mgmt/sqlvirtualmachine/models.go
@@ -1,6 +1,6 @@
 // +build go1.9
 
-// Copyright 2018 Microsoft Corporation
+// Copyright 2019 Microsoft Corporation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/profiles/preview/preview/sqlvirtualmachine/mgmt/sqlvirtualmachine/sqlvirtualmachineapi/models.go
+++ b/profiles/preview/preview/sqlvirtualmachine/mgmt/sqlvirtualmachine/sqlvirtualmachineapi/models.go
@@ -1,6 +1,6 @@
 // +build go1.9
 
-// Copyright 2018 Microsoft Corporation
+// Copyright 2019 Microsoft Corporation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/profiles/preview/preview/storage/datalake/storagedatalake/models.go
+++ b/profiles/preview/preview/storage/datalake/storagedatalake/models.go
@@ -1,6 +1,6 @@
 // +build go1.9
 
-// Copyright 2018 Microsoft Corporation
+// Copyright 2019 Microsoft Corporation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/profiles/preview/preview/storage/datalake/storagedatalake/storagedatalakeapi/models.go
+++ b/profiles/preview/preview/storage/datalake/storagedatalake/storagedatalakeapi/models.go
@@ -1,6 +1,6 @@
 // +build go1.9
 
-// Copyright 2018 Microsoft Corporation
+// Copyright 2019 Microsoft Corporation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/profiles/preview/preview/storage/mgmt/storage/models.go
+++ b/profiles/preview/preview/storage/mgmt/storage/models.go
@@ -1,6 +1,6 @@
 // +build go1.9
 
-// Copyright 2018 Microsoft Corporation
+// Copyright 2019 Microsoft Corporation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/profiles/preview/preview/storage/mgmt/storage/storageapi/models.go
+++ b/profiles/preview/preview/storage/mgmt/storage/storageapi/models.go
@@ -1,6 +1,6 @@
 // +build go1.9
 
-// Copyright 2018 Microsoft Corporation
+// Copyright 2019 Microsoft Corporation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/profiles/preview/preview/storagesync/mgmt/storagesync/models.go
+++ b/profiles/preview/preview/storagesync/mgmt/storagesync/models.go
@@ -1,6 +1,6 @@
 // +build go1.9
 
-// Copyright 2018 Microsoft Corporation
+// Copyright 2019 Microsoft Corporation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/profiles/preview/preview/storagesync/mgmt/storagesync/storagesyncapi/models.go
+++ b/profiles/preview/preview/storagesync/mgmt/storagesync/storagesyncapi/models.go
@@ -1,6 +1,6 @@
 // +build go1.9
 
-// Copyright 2018 Microsoft Corporation
+// Copyright 2019 Microsoft Corporation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/profiles/preview/preview/subscription/mgmt/subscription/models.go
+++ b/profiles/preview/preview/subscription/mgmt/subscription/models.go
@@ -1,6 +1,6 @@
 // +build go1.9
 
-// Copyright 2018 Microsoft Corporation
+// Copyright 2019 Microsoft Corporation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/profiles/preview/preview/subscription/mgmt/subscription/subscriptionapi/models.go
+++ b/profiles/preview/preview/subscription/mgmt/subscription/subscriptionapi/models.go
@@ -1,6 +1,6 @@
 // +build go1.9
 
-// Copyright 2018 Microsoft Corporation
+// Copyright 2019 Microsoft Corporation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/profiles/preview/preview/timeseriesinsights/mgmt/timeseriesinsights/models.go
+++ b/profiles/preview/preview/timeseriesinsights/mgmt/timeseriesinsights/models.go
@@ -1,6 +1,6 @@
 // +build go1.9
 
-// Copyright 2018 Microsoft Corporation
+// Copyright 2019 Microsoft Corporation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/profiles/preview/preview/timeseriesinsights/mgmt/timeseriesinsights/timeseriesinsightsapi/models.go
+++ b/profiles/preview/preview/timeseriesinsights/mgmt/timeseriesinsights/timeseriesinsightsapi/models.go
@@ -1,6 +1,6 @@
 // +build go1.9
 
-// Copyright 2018 Microsoft Corporation
+// Copyright 2019 Microsoft Corporation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/profiles/preview/preview/trafficmanager/mgmt/trafficmanager/models.go
+++ b/profiles/preview/preview/trafficmanager/mgmt/trafficmanager/models.go
@@ -1,6 +1,6 @@
 // +build go1.9
 
-// Copyright 2018 Microsoft Corporation
+// Copyright 2019 Microsoft Corporation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/profiles/preview/preview/trafficmanager/mgmt/trafficmanager/trafficmanagerapi/models.go
+++ b/profiles/preview/preview/trafficmanager/mgmt/trafficmanager/trafficmanagerapi/models.go
@@ -1,6 +1,6 @@
 // +build go1.9
 
-// Copyright 2018 Microsoft Corporation
+// Copyright 2019 Microsoft Corporation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/profiles/preview/preview/visualstudio/mgmt/visualstudio/models.go
+++ b/profiles/preview/preview/visualstudio/mgmt/visualstudio/models.go
@@ -1,6 +1,6 @@
 // +build go1.9
 
-// Copyright 2018 Microsoft Corporation
+// Copyright 2019 Microsoft Corporation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/profiles/preview/preview/visualstudio/mgmt/visualstudio/visualstudioapi/models.go
+++ b/profiles/preview/preview/visualstudio/mgmt/visualstudio/visualstudioapi/models.go
@@ -1,6 +1,6 @@
 // +build go1.9
 
-// Copyright 2018 Microsoft Corporation
+// Copyright 2019 Microsoft Corporation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/profiles/preview/preview/web/mgmt/web/models.go
+++ b/profiles/preview/preview/web/mgmt/web/models.go
@@ -1,6 +1,6 @@
 // +build go1.9
 
-// Copyright 2018 Microsoft Corporation
+// Copyright 2019 Microsoft Corporation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/profiles/preview/preview/web/mgmt/web/webapi/models.go
+++ b/profiles/preview/preview/web/mgmt/web/webapi/models.go
@@ -1,6 +1,6 @@
 // +build go1.9
 
-// Copyright 2018 Microsoft Corporation
+// Copyright 2019 Microsoft Corporation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/profiles/preview/preview/workloadmonitor/mgmt/workloadmonitor/models.go
+++ b/profiles/preview/preview/workloadmonitor/mgmt/workloadmonitor/models.go
@@ -1,6 +1,6 @@
 // +build go1.9
 
-// Copyright 2018 Microsoft Corporation
+// Copyright 2019 Microsoft Corporation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/profiles/preview/preview/workloadmonitor/mgmt/workloadmonitor/workloadmonitorapi/models.go
+++ b/profiles/preview/preview/workloadmonitor/mgmt/workloadmonitor/workloadmonitorapi/models.go
@@ -1,6 +1,6 @@
 // +build go1.9
 
-// Copyright 2018 Microsoft Corporation
+// Copyright 2019 Microsoft Corporation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/profiles/preview/provisioningservices/mgmt/iothub/iothubapi/models.go
+++ b/profiles/preview/provisioningservices/mgmt/iothub/iothubapi/models.go
@@ -1,6 +1,6 @@
 // +build go1.9
 
-// Copyright 2018 Microsoft Corporation
+// Copyright 2019 Microsoft Corporation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/profiles/preview/provisioningservices/mgmt/iothub/models.go
+++ b/profiles/preview/provisioningservices/mgmt/iothub/models.go
@@ -1,6 +1,6 @@
 // +build go1.9
 
-// Copyright 2018 Microsoft Corporation
+// Copyright 2019 Microsoft Corporation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/profiles/preview/recoveryservices/mgmt/backup/backupapi/models.go
+++ b/profiles/preview/recoveryservices/mgmt/backup/backupapi/models.go
@@ -1,6 +1,6 @@
 // +build go1.9
 
-// Copyright 2018 Microsoft Corporation
+// Copyright 2019 Microsoft Corporation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/profiles/preview/recoveryservices/mgmt/backup/models.go
+++ b/profiles/preview/recoveryservices/mgmt/backup/models.go
@@ -1,6 +1,6 @@
 // +build go1.9
 
-// Copyright 2018 Microsoft Corporation
+// Copyright 2019 Microsoft Corporation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/profiles/preview/recoveryservices/mgmt/recoveryservices/models.go
+++ b/profiles/preview/recoveryservices/mgmt/recoveryservices/models.go
@@ -1,6 +1,6 @@
 // +build go1.9
 
-// Copyright 2018 Microsoft Corporation
+// Copyright 2019 Microsoft Corporation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/profiles/preview/recoveryservices/mgmt/recoveryservices/recoveryservicesapi/models.go
+++ b/profiles/preview/recoveryservices/mgmt/recoveryservices/recoveryservicesapi/models.go
@@ -1,6 +1,6 @@
 // +build go1.9
 
-// Copyright 2018 Microsoft Corporation
+// Copyright 2019 Microsoft Corporation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/profiles/preview/recoveryservices/mgmt/siterecovery/models.go
+++ b/profiles/preview/recoveryservices/mgmt/siterecovery/models.go
@@ -1,6 +1,6 @@
 // +build go1.9
 
-// Copyright 2018 Microsoft Corporation
+// Copyright 2019 Microsoft Corporation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/profiles/preview/recoveryservices/mgmt/siterecovery/siterecoveryapi/models.go
+++ b/profiles/preview/recoveryservices/mgmt/siterecovery/siterecoveryapi/models.go
@@ -1,6 +1,6 @@
 // +build go1.9
 
-// Copyright 2018 Microsoft Corporation
+// Copyright 2019 Microsoft Corporation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/profiles/preview/redis/mgmt/redis/models.go
+++ b/profiles/preview/redis/mgmt/redis/models.go
@@ -1,6 +1,6 @@
 // +build go1.9
 
-// Copyright 2018 Microsoft Corporation
+// Copyright 2019 Microsoft Corporation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/profiles/preview/redis/mgmt/redis/redisapi/models.go
+++ b/profiles/preview/redis/mgmt/redis/redisapi/models.go
@@ -1,6 +1,6 @@
 // +build go1.9
 
-// Copyright 2018 Microsoft Corporation
+// Copyright 2019 Microsoft Corporation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/profiles/preview/relay/mgmt/relay/models.go
+++ b/profiles/preview/relay/mgmt/relay/models.go
@@ -1,6 +1,6 @@
 // +build go1.9
 
-// Copyright 2018 Microsoft Corporation
+// Copyright 2019 Microsoft Corporation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/profiles/preview/relay/mgmt/relay/relayapi/models.go
+++ b/profiles/preview/relay/mgmt/relay/relayapi/models.go
@@ -1,6 +1,6 @@
 // +build go1.9
 
-// Copyright 2018 Microsoft Corporation
+// Copyright 2019 Microsoft Corporation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/profiles/preview/reservations/mgmt/reservations/models.go
+++ b/profiles/preview/reservations/mgmt/reservations/models.go
@@ -1,6 +1,6 @@
 // +build go1.9
 
-// Copyright 2018 Microsoft Corporation
+// Copyright 2019 Microsoft Corporation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/profiles/preview/reservations/mgmt/reservations/reservationsapi/models.go
+++ b/profiles/preview/reservations/mgmt/reservations/reservationsapi/models.go
@@ -1,6 +1,6 @@
 // +build go1.9
 
-// Copyright 2018 Microsoft Corporation
+// Copyright 2019 Microsoft Corporation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/profiles/preview/resourcehealth/mgmt/resourcehealth/models.go
+++ b/profiles/preview/resourcehealth/mgmt/resourcehealth/models.go
@@ -1,6 +1,6 @@
 // +build go1.9
 
-// Copyright 2018 Microsoft Corporation
+// Copyright 2019 Microsoft Corporation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/profiles/preview/resourcehealth/mgmt/resourcehealth/resourcehealthapi/models.go
+++ b/profiles/preview/resourcehealth/mgmt/resourcehealth/resourcehealthapi/models.go
@@ -1,6 +1,6 @@
 // +build go1.9
 
-// Copyright 2018 Microsoft Corporation
+// Copyright 2019 Microsoft Corporation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/profiles/preview/resources/mgmt/features/featuresapi/models.go
+++ b/profiles/preview/resources/mgmt/features/featuresapi/models.go
@@ -1,6 +1,6 @@
 // +build go1.9
 
-// Copyright 2018 Microsoft Corporation
+// Copyright 2019 Microsoft Corporation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/profiles/preview/resources/mgmt/features/models.go
+++ b/profiles/preview/resources/mgmt/features/models.go
@@ -1,6 +1,6 @@
 // +build go1.9
 
-// Copyright 2018 Microsoft Corporation
+// Copyright 2019 Microsoft Corporation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/profiles/preview/resources/mgmt/links/linksapi/models.go
+++ b/profiles/preview/resources/mgmt/links/linksapi/models.go
@@ -1,6 +1,6 @@
 // +build go1.9
 
-// Copyright 2018 Microsoft Corporation
+// Copyright 2019 Microsoft Corporation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/profiles/preview/resources/mgmt/links/models.go
+++ b/profiles/preview/resources/mgmt/links/models.go
@@ -1,6 +1,6 @@
 // +build go1.9
 
-// Copyright 2018 Microsoft Corporation
+// Copyright 2019 Microsoft Corporation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/profiles/preview/resources/mgmt/locks/locksapi/models.go
+++ b/profiles/preview/resources/mgmt/locks/locksapi/models.go
@@ -1,6 +1,6 @@
 // +build go1.9
 
-// Copyright 2018 Microsoft Corporation
+// Copyright 2019 Microsoft Corporation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/profiles/preview/resources/mgmt/locks/models.go
+++ b/profiles/preview/resources/mgmt/locks/models.go
@@ -1,6 +1,6 @@
 // +build go1.9
 
-// Copyright 2018 Microsoft Corporation
+// Copyright 2019 Microsoft Corporation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/profiles/preview/resources/mgmt/managedapplications/managedapplicationsapi/models.go
+++ b/profiles/preview/resources/mgmt/managedapplications/managedapplicationsapi/models.go
@@ -1,6 +1,6 @@
 // +build go1.9
 
-// Copyright 2018 Microsoft Corporation
+// Copyright 2019 Microsoft Corporation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/profiles/preview/resources/mgmt/managedapplications/models.go
+++ b/profiles/preview/resources/mgmt/managedapplications/models.go
@@ -1,6 +1,6 @@
 // +build go1.9
 
-// Copyright 2018 Microsoft Corporation
+// Copyright 2019 Microsoft Corporation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/profiles/preview/resources/mgmt/policy/models.go
+++ b/profiles/preview/resources/mgmt/policy/models.go
@@ -1,6 +1,6 @@
 // +build go1.9
 
-// Copyright 2018 Microsoft Corporation
+// Copyright 2019 Microsoft Corporation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/profiles/preview/resources/mgmt/policy/policyapi/models.go
+++ b/profiles/preview/resources/mgmt/policy/policyapi/models.go
@@ -1,6 +1,6 @@
 // +build go1.9
 
-// Copyright 2018 Microsoft Corporation
+// Copyright 2019 Microsoft Corporation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/profiles/preview/resources/mgmt/resources/models.go
+++ b/profiles/preview/resources/mgmt/resources/models.go
@@ -1,6 +1,6 @@
 // +build go1.9
 
-// Copyright 2018 Microsoft Corporation
+// Copyright 2019 Microsoft Corporation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/profiles/preview/resources/mgmt/resources/resourcesapi/models.go
+++ b/profiles/preview/resources/mgmt/resources/resourcesapi/models.go
@@ -1,6 +1,6 @@
 // +build go1.9
 
-// Copyright 2018 Microsoft Corporation
+// Copyright 2019 Microsoft Corporation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/profiles/preview/resources/mgmt/subscriptions/models.go
+++ b/profiles/preview/resources/mgmt/subscriptions/models.go
@@ -1,6 +1,6 @@
 // +build go1.9
 
-// Copyright 2018 Microsoft Corporation
+// Copyright 2019 Microsoft Corporation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/profiles/preview/resources/mgmt/subscriptions/subscriptionsapi/models.go
+++ b/profiles/preview/resources/mgmt/subscriptions/subscriptionsapi/models.go
@@ -1,6 +1,6 @@
 // +build go1.9
 
-// Copyright 2018 Microsoft Corporation
+// Copyright 2019 Microsoft Corporation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/profiles/preview/scheduler/mgmt/scheduler/models.go
+++ b/profiles/preview/scheduler/mgmt/scheduler/models.go
@@ -1,6 +1,6 @@
 // +build go1.9
 
-// Copyright 2018 Microsoft Corporation
+// Copyright 2019 Microsoft Corporation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/profiles/preview/scheduler/mgmt/scheduler/schedulerapi/models.go
+++ b/profiles/preview/scheduler/mgmt/scheduler/schedulerapi/models.go
@@ -1,6 +1,6 @@
 // +build go1.9
 
-// Copyright 2018 Microsoft Corporation
+// Copyright 2019 Microsoft Corporation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/profiles/preview/search/mgmt/search/models.go
+++ b/profiles/preview/search/mgmt/search/models.go
@@ -1,6 +1,6 @@
 // +build go1.9
 
-// Copyright 2018 Microsoft Corporation
+// Copyright 2019 Microsoft Corporation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/profiles/preview/search/mgmt/search/searchapi/models.go
+++ b/profiles/preview/search/mgmt/search/searchapi/models.go
@@ -1,6 +1,6 @@
 // +build go1.9
 
-// Copyright 2018 Microsoft Corporation
+// Copyright 2019 Microsoft Corporation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/profiles/preview/servicebus/mgmt/servicebus/models.go
+++ b/profiles/preview/servicebus/mgmt/servicebus/models.go
@@ -1,6 +1,6 @@
 // +build go1.9
 
-// Copyright 2018 Microsoft Corporation
+// Copyright 2019 Microsoft Corporation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/profiles/preview/servicebus/mgmt/servicebus/servicebusapi/models.go
+++ b/profiles/preview/servicebus/mgmt/servicebus/servicebusapi/models.go
@@ -1,6 +1,6 @@
 // +build go1.9
 
-// Copyright 2018 Microsoft Corporation
+// Copyright 2019 Microsoft Corporation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/profiles/preview/servicefabric/mgmt/servicefabric/models.go
+++ b/profiles/preview/servicefabric/mgmt/servicefabric/models.go
@@ -1,6 +1,6 @@
 // +build go1.9
 
-// Copyright 2018 Microsoft Corporation
+// Copyright 2019 Microsoft Corporation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/profiles/preview/servicefabric/servicefabric/models.go
+++ b/profiles/preview/servicefabric/servicefabric/models.go
@@ -1,6 +1,6 @@
 // +build go1.9
 
-// Copyright 2018 Microsoft Corporation
+// Copyright 2019 Microsoft Corporation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/profiles/preview/servicefabric/servicefabric/servicefabricapi/models.go
+++ b/profiles/preview/servicefabric/servicefabric/servicefabricapi/models.go
@@ -1,6 +1,6 @@
 // +build go1.9
 
-// Copyright 2018 Microsoft Corporation
+// Copyright 2019 Microsoft Corporation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/profiles/preview/signalr/mgmt/signalr/models.go
+++ b/profiles/preview/signalr/mgmt/signalr/models.go
@@ -1,6 +1,6 @@
 // +build go1.9
 
-// Copyright 2018 Microsoft Corporation
+// Copyright 2019 Microsoft Corporation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/profiles/preview/signalr/mgmt/signalr/signalrapi/models.go
+++ b/profiles/preview/signalr/mgmt/signalr/signalrapi/models.go
@@ -1,6 +1,6 @@
 // +build go1.9
 
-// Copyright 2018 Microsoft Corporation
+// Copyright 2019 Microsoft Corporation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/profiles/preview/sql/mgmt/sql/models.go
+++ b/profiles/preview/sql/mgmt/sql/models.go
@@ -1,6 +1,6 @@
 // +build go1.9
 
-// Copyright 2018 Microsoft Corporation
+// Copyright 2019 Microsoft Corporation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/profiles/preview/sql/mgmt/sql/sqlapi/models.go
+++ b/profiles/preview/sql/mgmt/sql/sqlapi/models.go
@@ -1,6 +1,6 @@
 // +build go1.9
 
-// Copyright 2018 Microsoft Corporation
+// Copyright 2019 Microsoft Corporation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/profiles/preview/stable/storage/datalake/storagedatalake/models.go
+++ b/profiles/preview/stable/storage/datalake/storagedatalake/models.go
@@ -1,6 +1,6 @@
 // +build go1.9
 
-// Copyright 2018 Microsoft Corporation
+// Copyright 2019 Microsoft Corporation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/profiles/preview/stable/storage/datalake/storagedatalake/storagedatalakeapi/models.go
+++ b/profiles/preview/stable/storage/datalake/storagedatalake/storagedatalakeapi/models.go
@@ -1,6 +1,6 @@
 // +build go1.9
 
-// Copyright 2018 Microsoft Corporation
+// Copyright 2019 Microsoft Corporation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/profiles/preview/storage/datalake/storagedatalake/models.go
+++ b/profiles/preview/storage/datalake/storagedatalake/models.go
@@ -1,6 +1,6 @@
 // +build go1.9
 
-// Copyright 2018 Microsoft Corporation
+// Copyright 2019 Microsoft Corporation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/profiles/preview/storage/datalake/storagedatalake/storagedatalakeapi/models.go
+++ b/profiles/preview/storage/datalake/storagedatalake/storagedatalakeapi/models.go
@@ -1,6 +1,6 @@
 // +build go1.9
 
-// Copyright 2018 Microsoft Corporation
+// Copyright 2019 Microsoft Corporation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/profiles/preview/storage/mgmt/storage/models.go
+++ b/profiles/preview/storage/mgmt/storage/models.go
@@ -1,6 +1,6 @@
 // +build go1.9
 
-// Copyright 2018 Microsoft Corporation
+// Copyright 2019 Microsoft Corporation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/profiles/preview/storage/mgmt/storage/storageapi/models.go
+++ b/profiles/preview/storage/mgmt/storage/storageapi/models.go
@@ -1,6 +1,6 @@
 // +build go1.9
 
-// Copyright 2018 Microsoft Corporation
+// Copyright 2019 Microsoft Corporation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/profiles/preview/storageimportexport/mgmt/storageimportexport/models.go
+++ b/profiles/preview/storageimportexport/mgmt/storageimportexport/models.go
@@ -1,6 +1,6 @@
 // +build go1.9
 
-// Copyright 2018 Microsoft Corporation
+// Copyright 2019 Microsoft Corporation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/profiles/preview/storageimportexport/mgmt/storageimportexport/storageimportexportapi/models.go
+++ b/profiles/preview/storageimportexport/mgmt/storageimportexport/storageimportexportapi/models.go
@@ -1,6 +1,6 @@
 // +build go1.9
 
-// Copyright 2018 Microsoft Corporation
+// Copyright 2019 Microsoft Corporation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/profiles/preview/storagesync/mgmt/storagesync/models.go
+++ b/profiles/preview/storagesync/mgmt/storagesync/models.go
@@ -1,6 +1,6 @@
 // +build go1.9
 
-// Copyright 2018 Microsoft Corporation
+// Copyright 2019 Microsoft Corporation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/profiles/preview/storagesync/mgmt/storagesync/storagesyncapi/models.go
+++ b/profiles/preview/storagesync/mgmt/storagesync/storagesyncapi/models.go
@@ -1,6 +1,6 @@
 // +build go1.9
 
-// Copyright 2018 Microsoft Corporation
+// Copyright 2019 Microsoft Corporation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/profiles/preview/storsimple1200series/mgmt/storsimple/models.go
+++ b/profiles/preview/storsimple1200series/mgmt/storsimple/models.go
@@ -1,6 +1,6 @@
 // +build go1.9
 
-// Copyright 2018 Microsoft Corporation
+// Copyright 2019 Microsoft Corporation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/profiles/preview/storsimple1200series/mgmt/storsimple/storsimpleapi/models.go
+++ b/profiles/preview/storsimple1200series/mgmt/storsimple/storsimpleapi/models.go
@@ -1,6 +1,6 @@
 // +build go1.9
 
-// Copyright 2018 Microsoft Corporation
+// Copyright 2019 Microsoft Corporation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/profiles/preview/storsimple8000series/mgmt/storsimple/models.go
+++ b/profiles/preview/storsimple8000series/mgmt/storsimple/models.go
@@ -1,6 +1,6 @@
 // +build go1.9
 
-// Copyright 2018 Microsoft Corporation
+// Copyright 2019 Microsoft Corporation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/profiles/preview/storsimple8000series/mgmt/storsimple/storsimpleapi/models.go
+++ b/profiles/preview/storsimple8000series/mgmt/storsimple/storsimpleapi/models.go
@@ -1,6 +1,6 @@
 // +build go1.9
 
-// Copyright 2018 Microsoft Corporation
+// Copyright 2019 Microsoft Corporation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/profiles/preview/streamanalytics/mgmt/streamanalytics/models.go
+++ b/profiles/preview/streamanalytics/mgmt/streamanalytics/models.go
@@ -1,6 +1,6 @@
 // +build go1.9
 
-// Copyright 2018 Microsoft Corporation
+// Copyright 2019 Microsoft Corporation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/profiles/preview/streamanalytics/mgmt/streamanalytics/streamanalyticsapi/models.go
+++ b/profiles/preview/streamanalytics/mgmt/streamanalytics/streamanalyticsapi/models.go
@@ -1,6 +1,6 @@
 // +build go1.9
 
-// Copyright 2018 Microsoft Corporation
+// Copyright 2019 Microsoft Corporation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/profiles/preview/timeseriesinsights/mgmt/timeseriesinsights/models.go
+++ b/profiles/preview/timeseriesinsights/mgmt/timeseriesinsights/models.go
@@ -1,6 +1,6 @@
 // +build go1.9
 
-// Copyright 2018 Microsoft Corporation
+// Copyright 2019 Microsoft Corporation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/profiles/preview/timeseriesinsights/mgmt/timeseriesinsights/timeseriesinsightsapi/models.go
+++ b/profiles/preview/timeseriesinsights/mgmt/timeseriesinsights/timeseriesinsightsapi/models.go
@@ -1,6 +1,6 @@
 // +build go1.9
 
-// Copyright 2018 Microsoft Corporation
+// Copyright 2019 Microsoft Corporation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/profiles/preview/trafficmanager/mgmt/trafficmanager/models.go
+++ b/profiles/preview/trafficmanager/mgmt/trafficmanager/models.go
@@ -1,6 +1,6 @@
 // +build go1.9
 
-// Copyright 2018 Microsoft Corporation
+// Copyright 2019 Microsoft Corporation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/profiles/preview/trafficmanager/mgmt/trafficmanager/trafficmanagerapi/models.go
+++ b/profiles/preview/trafficmanager/mgmt/trafficmanager/trafficmanagerapi/models.go
@@ -1,6 +1,6 @@
 // +build go1.9
 
-// Copyright 2018 Microsoft Corporation
+// Copyright 2019 Microsoft Corporation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/profiles/preview/web/mgmt/web/models.go
+++ b/profiles/preview/web/mgmt/web/models.go
@@ -1,6 +1,6 @@
 // +build go1.9
 
-// Copyright 2018 Microsoft Corporation
+// Copyright 2019 Microsoft Corporation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/profiles/preview/web/mgmt/web/webapi/models.go
+++ b/profiles/preview/web/mgmt/web/webapi/models.go
@@ -1,6 +1,6 @@
 // +build go1.9
 
-// Copyright 2018 Microsoft Corporation
+// Copyright 2019 Microsoft Corporation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/services/preview/automation/mgmt/2017-05-15-preview/automation/models.go
+++ b/services/preview/automation/mgmt/2017-05-15-preview/automation/models.go
@@ -6343,6 +6343,14 @@ type ModuleUpdateProperties struct {
 	ContentLink *ContentLink `json:"contentLink,omitempty"`
 }
 
+// NonAzureQueryProperties non Azure query for the update configuration.
+type NonAzureQueryProperties struct {
+	// FunctionAlias - Log Analytics Saved Search name.
+	FunctionAlias *string `json:"functionAlias,omitempty"`
+	// WorkspaceID - Workspace Id for Log Analytics in which the saved Search is resided.
+	WorkspaceID *string `json:"workspaceId,omitempty"`
+}
+
 // Operation automation REST API operation
 type Operation struct {
 	// Name - Operation name: {provider}/{resource}/{operation}
@@ -9007,6 +9015,8 @@ func (tsp TagSettingsProperties) MarshalJSON() ([]byte, error) {
 type TargetProperties struct {
 	// AzureQueries - List of Azure queries in the software update configuration.
 	AzureQueries *[]AzureQueryProperties `json:"azureQueries,omitempty"`
+	// NonAzureQueries - List of non Azure queries in the software update configuration.
+	NonAzureQueries *[]NonAzureQueryProperties `json:"nonAzureQueries,omitempty"`
 }
 
 // TaskProperties task properties of the software update configuration.

--- a/services/preview/automation/mgmt/2018-01-15-preview/automation/models.go
+++ b/services/preview/automation/mgmt/2018-01-15-preview/automation/models.go
@@ -6821,6 +6821,14 @@ type NodeCounts struct {
 	TotalCount *int32 `json:"totalCount,omitempty"`
 }
 
+// NonAzureQueryProperties non Azure query for the update configuration.
+type NonAzureQueryProperties struct {
+	// FunctionAlias - Log Analytics Saved Search name.
+	FunctionAlias *string `json:"functionAlias,omitempty"`
+	// WorkspaceID - Workspace Id for Log Analytics in which the saved Search is resided.
+	WorkspaceID *string `json:"workspaceId,omitempty"`
+}
+
 // Operation automation REST API operation
 type Operation struct {
 	// Name - Operation name: {provider}/{resource}/{operation}
@@ -9485,6 +9493,8 @@ func (tsp TagSettingsProperties) MarshalJSON() ([]byte, error) {
 type TargetProperties struct {
 	// AzureQueries - List of Azure queries in the software update configuration.
 	AzureQueries *[]AzureQueryProperties `json:"azureQueries,omitempty"`
+	// NonAzureQueries - List of non Azure queries in the software update configuration.
+	NonAzureQueries *[]NonAzureQueryProperties `json:"nonAzureQueries,omitempty"`
 }
 
 // TaskProperties task properties of the software update configuration.

--- a/services/preview/automation/mgmt/2018-06-30-preview/automation/models.go
+++ b/services/preview/automation/mgmt/2018-06-30-preview/automation/models.go
@@ -6821,6 +6821,14 @@ type NodeCounts struct {
 	TotalCount *int32 `json:"totalCount,omitempty"`
 }
 
+// NonAzureQueryProperties non Azure query for the update configuration.
+type NonAzureQueryProperties struct {
+	// FunctionAlias - Log Analytics Saved Search name.
+	FunctionAlias *string `json:"functionAlias,omitempty"`
+	// WorkspaceID - Workspace Id for Log Analytics in which the saved Search is resided.
+	WorkspaceID *string `json:"workspaceId,omitempty"`
+}
+
 // Operation automation REST API operation
 type Operation struct {
 	// Name - Operation name: {provider}/{resource}/{operation}
@@ -9559,6 +9567,8 @@ func (tsp TagSettingsProperties) MarshalJSON() ([]byte, error) {
 type TargetProperties struct {
 	// AzureQueries - List of Azure queries in the software update configuration.
 	AzureQueries *[]AzureQueryProperties `json:"azureQueries,omitempty"`
+	// NonAzureQueries - List of non Azure queries in the software update configuration.
+	NonAzureQueries *[]NonAzureQueryProperties `json:"nonAzureQueries,omitempty"`
 }
 
 // TaskProperties task properties of the software update configuration.

--- a/services/preview/hanaonazure/mgmt/2017-11-03-preview/hanaonazure/hanainstances.go
+++ b/services/preview/hanaonazure/mgmt/2017-11-03-preview/hanaonazure/hanainstances.go
@@ -417,3 +417,84 @@ func (client HanaInstancesClient) RestartResponder(resp *http.Response) (result 
 	result.Response = resp
 	return
 }
+
+// Update patches the Tags field of a SAP HANA instance for the specified subscription, resource group, and instance
+// name.
+// Parameters:
+// resourceGroupName - name of the resource group.
+// hanaInstanceName - name of the SAP HANA on Azure instance.
+// tagsParameter - request body that only contains the new Tags field
+func (client HanaInstancesClient) Update(ctx context.Context, resourceGroupName string, hanaInstanceName string, tagsParameter Tags) (result HanaInstance, err error) {
+	if tracing.IsEnabled() {
+		ctx = tracing.StartSpan(ctx, fqdn+"/HanaInstancesClient.Update")
+		defer func() {
+			sc := -1
+			if result.Response.Response != nil {
+				sc = result.Response.Response.StatusCode
+			}
+			tracing.EndSpan(ctx, sc, err)
+		}()
+	}
+	req, err := client.UpdatePreparer(ctx, resourceGroupName, hanaInstanceName, tagsParameter)
+	if err != nil {
+		err = autorest.NewErrorWithError(err, "hanaonazure.HanaInstancesClient", "Update", nil, "Failure preparing request")
+		return
+	}
+
+	resp, err := client.UpdateSender(req)
+	if err != nil {
+		result.Response = autorest.Response{Response: resp}
+		err = autorest.NewErrorWithError(err, "hanaonazure.HanaInstancesClient", "Update", resp, "Failure sending request")
+		return
+	}
+
+	result, err = client.UpdateResponder(resp)
+	if err != nil {
+		err = autorest.NewErrorWithError(err, "hanaonazure.HanaInstancesClient", "Update", resp, "Failure responding to request")
+	}
+
+	return
+}
+
+// UpdatePreparer prepares the Update request.
+func (client HanaInstancesClient) UpdatePreparer(ctx context.Context, resourceGroupName string, hanaInstanceName string, tagsParameter Tags) (*http.Request, error) {
+	pathParameters := map[string]interface{}{
+		"hanaInstanceName":  autorest.Encode("path", hanaInstanceName),
+		"resourceGroupName": autorest.Encode("path", resourceGroupName),
+		"subscriptionId":    autorest.Encode("path", client.SubscriptionID),
+	}
+
+	const APIVersion = "2017-11-03-preview"
+	queryParameters := map[string]interface{}{
+		"api-version": APIVersion,
+	}
+
+	preparer := autorest.CreatePreparer(
+		autorest.AsContentType("application/json; charset=utf-8"),
+		autorest.AsPatch(),
+		autorest.WithBaseURL(client.BaseURI),
+		autorest.WithPathParameters("/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.HanaOnAzure/hanaInstances/{hanaInstanceName}", pathParameters),
+		autorest.WithJSON(tagsParameter),
+		autorest.WithQueryParameters(queryParameters))
+	return preparer.Prepare((&http.Request{}).WithContext(ctx))
+}
+
+// UpdateSender sends the Update request. The method will close the
+// http.Response Body if it receives an error.
+func (client HanaInstancesClient) UpdateSender(req *http.Request) (*http.Response, error) {
+	return autorest.SendWithSender(client, req,
+		azure.DoRetryWithRegistration(client.Client))
+}
+
+// UpdateResponder handles the response to the Update request. The method always
+// closes the http.Response Body.
+func (client HanaInstancesClient) UpdateResponder(resp *http.Response) (result HanaInstance, err error) {
+	err = autorest.Respond(
+		resp,
+		client.ByInspecting(),
+		azure.WithErrorUnlessStatusCode(http.StatusOK),
+		autorest.ByUnmarshallingJSON(&result),
+		autorest.ByClosing())
+	result.Response = autorest.Response{Response: resp}
+	return
+}

--- a/services/preview/hanaonazure/mgmt/2017-11-03-preview/hanaonazure/hanaonazureapi/interfaces.go
+++ b/services/preview/hanaonazure/mgmt/2017-11-03-preview/hanaonazure/hanaonazureapi/interfaces.go
@@ -36,6 +36,7 @@ type HanaInstancesClientAPI interface {
 	List(ctx context.Context) (result hanaonazure.HanaInstancesListResultPage, err error)
 	ListByResourceGroup(ctx context.Context, resourceGroupName string) (result hanaonazure.HanaInstancesListResultPage, err error)
 	Restart(ctx context.Context, resourceGroupName string, hanaInstanceName string) (result autorest.Response, err error)
+	Update(ctx context.Context, resourceGroupName string, hanaInstanceName string, tagsParameter hanaonazure.Tags) (result hanaonazure.HanaInstance, err error)
 }
 
 var _ HanaInstancesClientAPI = (*hanaonazure.HanaInstancesClient)(nil)

--- a/services/preview/hanaonazure/mgmt/2017-11-03-preview/hanaonazure/models.go
+++ b/services/preview/hanaonazure/mgmt/2017-11-03-preview/hanaonazure/models.go
@@ -507,3 +507,18 @@ type StorageProfile struct {
 	// OsDisks - Specifies information about the operating system disk used by the hana instance.
 	OsDisks *[]Disk `json:"osDisks,omitempty"`
 }
+
+// Tags tags field of the HANA instance.
+type Tags struct {
+	// Tags - Tags field of the HANA instance.
+	Tags map[string]*string `json:"tags"`
+}
+
+// MarshalJSON is the custom marshaler for Tags.
+func (t Tags) MarshalJSON() ([]byte, error) {
+	objectMap := make(map[string]interface{})
+	if t.Tags != nil {
+		objectMap["tags"] = t.Tags
+	}
+	return json.Marshal(objectMap)
+}

--- a/services/preview/storage/mgmt/2015-05-01-preview/storage/models.go
+++ b/services/preview/storage/mgmt/2015-05-01-preview/storage/models.go
@@ -713,8 +713,8 @@ type CheckNameAvailabilityResult struct {
 type CustomDomain struct {
 	// Name - Gets or sets the custom domain name. Name is the CNAME source.
 	Name *string `json:"name,omitempty"`
-	// UseSubDomain - Indicates whether indirect CName validation is enabled. Default value is false. This should only be set on updates
-	UseSubDomain *bool `json:"useSubDomain,omitempty"`
+	// UseSubDomainName - Indicates whether indirect CName validation is enabled. Default value is false. This should only be set on updates
+	UseSubDomainName *bool `json:"useSubDomainName,omitempty"`
 }
 
 // Endpoints the URIs that are used to perform a retrieval of a public blob, queue or table object.

--- a/services/preview/storage/mgmt/2018-03-01-preview/storage/models.go
+++ b/services/preview/storage/mgmt/2018-03-01-preview/storage/models.go
@@ -1258,8 +1258,8 @@ func (cp ContainerProperties) MarshalJSON() ([]byte, error) {
 type CustomDomain struct {
 	// Name - Gets or sets the custom domain name assigned to the storage account. Name is the CNAME source.
 	Name *string `json:"name,omitempty"`
-	// UseSubDomain - Indicates whether indirect CName validation is enabled. Default value is false. This should only be set on updates.
-	UseSubDomain *bool `json:"useSubDomain,omitempty"`
+	// UseSubDomainName - Indicates whether indirect CName validation is enabled. Default value is false. This should only be set on updates.
+	UseSubDomainName *bool `json:"useSubDomainName,omitempty"`
 }
 
 // Dimension dimension of blobs, possibly be blob type or access tier.

--- a/services/storage/mgmt/2015-06-15/storage/models.go
+++ b/services/storage/mgmt/2015-06-15/storage/models.go
@@ -458,8 +458,8 @@ type CheckNameAvailabilityResult struct {
 type CustomDomain struct {
 	// Name - The custom domain name. Name is the CNAME source.
 	Name *string `json:"name,omitempty"`
-	// UseSubDomain - Indicates whether indirect CName validation is enabled. Default value is false. This should only be set on updates
-	UseSubDomain *bool `json:"useSubDomain,omitempty"`
+	// UseSubDomainName - Indicates whether indirect CName validation is enabled. Default value is false. This should only be set on updates
+	UseSubDomainName *bool `json:"useSubDomainName,omitempty"`
 }
 
 // Endpoints the URIs that are used to perform a retrieval of a public blob, queue or table object.

--- a/services/storage/mgmt/2016-01-01/storage/models.go
+++ b/services/storage/mgmt/2016-01-01/storage/models.go
@@ -604,8 +604,8 @@ type CheckNameAvailabilityResult struct {
 type CustomDomain struct {
 	// Name - Gets or sets the custom domain name assigned to the storage account. Name is the CNAME source.
 	Name *string `json:"name,omitempty"`
-	// UseSubDomain - Indicates whether indirect CName validation is enabled. Default value is false. This should only be set on updates.
-	UseSubDomain *bool `json:"useSubDomain,omitempty"`
+	// UseSubDomainName - Indicates whether indirect CName validation is enabled. Default value is false. This should only be set on updates.
+	UseSubDomainName *bool `json:"useSubDomainName,omitempty"`
 }
 
 // Encryption the encryption settings on the storage account.

--- a/services/storage/mgmt/2016-05-01/storage/models.go
+++ b/services/storage/mgmt/2016-05-01/storage/models.go
@@ -749,8 +749,8 @@ type CheckNameAvailabilityResult struct {
 type CustomDomain struct {
 	// Name - Gets or sets the custom domain name assigned to the storage account. Name is the CNAME source.
 	Name *string `json:"name,omitempty"`
-	// UseSubDomain - Indicates whether indirect CName validation is enabled. Default value is false. This should only be set on updates.
-	UseSubDomain *bool `json:"useSubDomain,omitempty"`
+	// UseSubDomainName - Indicates whether indirect CName validation is enabled. Default value is false. This should only be set on updates.
+	UseSubDomainName *bool `json:"useSubDomainName,omitempty"`
 }
 
 // Encryption the encryption settings on the storage account.

--- a/services/storage/mgmt/2016-12-01/storage/models.go
+++ b/services/storage/mgmt/2016-12-01/storage/models.go
@@ -755,8 +755,8 @@ type CheckNameAvailabilityResult struct {
 type CustomDomain struct {
 	// Name - Gets or sets the custom domain name assigned to the storage account. Name is the CNAME source.
 	Name *string `json:"name,omitempty"`
-	// UseSubDomain - Indicates whether indirect CName validation is enabled. Default value is false. This should only be set on updates.
-	UseSubDomain *bool `json:"useSubDomain,omitempty"`
+	// UseSubDomainName - Indicates whether indirect CName validation is enabled. Default value is false. This should only be set on updates.
+	UseSubDomainName *bool `json:"useSubDomainName,omitempty"`
 }
 
 // Encryption the encryption settings on the storage account.

--- a/services/storage/mgmt/2017-06-01/storage/models.go
+++ b/services/storage/mgmt/2017-06-01/storage/models.go
@@ -880,8 +880,8 @@ type CheckNameAvailabilityResult struct {
 type CustomDomain struct {
 	// Name - Gets or sets the custom domain name assigned to the storage account. Name is the CNAME source.
 	Name *string `json:"name,omitempty"`
-	// UseSubDomain - Indicates whether indirect CName validation is enabled. Default value is false. This should only be set on updates.
-	UseSubDomain *bool `json:"useSubDomain,omitempty"`
+	// UseSubDomainName - Indicates whether indirect CName validation is enabled. Default value is false. This should only be set on updates.
+	UseSubDomainName *bool `json:"useSubDomainName,omitempty"`
 }
 
 // Dimension dimension of blobs, possibly be blob type or access tier.

--- a/services/storage/mgmt/2017-10-01/storage/models.go
+++ b/services/storage/mgmt/2017-10-01/storage/models.go
@@ -896,8 +896,8 @@ type CheckNameAvailabilityResult struct {
 type CustomDomain struct {
 	// Name - Gets or sets the custom domain name assigned to the storage account. Name is the CNAME source.
 	Name *string `json:"name,omitempty"`
-	// UseSubDomain - Indicates whether indirect CName validation is enabled. Default value is false. This should only be set on updates.
-	UseSubDomain *bool `json:"useSubDomain,omitempty"`
+	// UseSubDomainName - Indicates whether indirect CName validation is enabled. Default value is false. This should only be set on updates.
+	UseSubDomainName *bool `json:"useSubDomainName,omitempty"`
 }
 
 // Dimension dimension of blobs, possibly be blob type or access tier.

--- a/services/storage/mgmt/2018-02-01/storage/models.go
+++ b/services/storage/mgmt/2018-02-01/storage/models.go
@@ -1168,8 +1168,8 @@ func (cp ContainerProperties) MarshalJSON() ([]byte, error) {
 type CustomDomain struct {
 	// Name - Gets or sets the custom domain name assigned to the storage account. Name is the CNAME source.
 	Name *string `json:"name,omitempty"`
-	// UseSubDomain - Indicates whether indirect CName validation is enabled. Default value is false. This should only be set on updates.
-	UseSubDomain *bool `json:"useSubDomain,omitempty"`
+	// UseSubDomainName - Indicates whether indirect CName validation is enabled. Default value is false. This should only be set on updates.
+	UseSubDomainName *bool `json:"useSubDomainName,omitempty"`
 }
 
 // Dimension dimension of blobs, possibly be blob type or access tier.

--- a/services/storage/mgmt/2018-07-01/storage/models.go
+++ b/services/storage/mgmt/2018-07-01/storage/models.go
@@ -1439,8 +1439,8 @@ type CorsRules struct {
 type CustomDomain struct {
 	// Name - Gets or sets the custom domain name assigned to the storage account. Name is the CNAME source.
 	Name *string `json:"name,omitempty"`
-	// UseSubDomain - Indicates whether indirect CName validation is enabled. Default value is false. This should only be set on updates.
-	UseSubDomain *bool `json:"useSubDomain,omitempty"`
+	// UseSubDomainName - Indicates whether indirect CName validation is enabled. Default value is false. This should only be set on updates.
+	UseSubDomainName *bool `json:"useSubDomainName,omitempty"`
 }
 
 // DeleteRetentionPolicy the blob service properties for soft delete.


### PR DESCRIPTION
Targetting lastest branch

Several large enterprises still extensively use Azure PaaS V1 (Cloud Services a.k.a. Web/Worker Roles) through the classic management API (ASM). These are early adopters of the Azure cloud platform and will take singificant migration effort to move to newer Compute options available via Azure Resource Manager (ARM).
Newer cross platform automation options (azure cli, Az Powershell Module) do not provide support for ASM, which makes it non feasible to run on non windows environment (e.g:- Linux Containers as part of CI/CD).
This pull request wraps the ASM API and adds support for the common workflows such as deploying cloud service packages to production or staging slots of a cloud service and performing blue/green style deployment with VIP Swap. It also adds support for managing extensions for cloud services which are needed for enabling extension such as PaaS Diagnostics (a.k.a. WAD a.k.a. Windows Azure Diagnostics) and Microsoft AntiMalware extensions.